### PR TITLE
Create .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,3 @@
-[run]
-omit =
-    tests/*
-
 [report]
 exclude_lines =
     # Skip any pass lines such as may be used for @abstractmethod


### PR DESCRIPTION
Adding the configuration file for coverage with the aim of removing the tests folder from the coverage and excluding lines such as `pass` or not implemented errors