### PR TITLE
added fix to knapsack and slackfreeknapsack random_instance

### DIFF
--- a/openqaoa/problems/problem.py
+++ b/openqaoa/problems/problem.py
@@ -642,7 +642,8 @@ class Knapsack(Problem):
 
         min_weights = np.min(weights)
         max_weights = np.max(weights)
-        if min_weights * n_items + 1 < max_weights * n_items :
+
+        if min_weights != max_weights:
             weight_capacity = np.random.randint(min_weights * n_items, max_weights * n_items)
         else:
             weight_capacity = np.random.randint(max_weights, max_weights * n_items)
@@ -786,7 +787,7 @@ class SlackFreeKnapsack(Knapsack):
 
         min_weights = np.min(weights)
         max_weights = np.max(weights)
-        if min_weights * n_items + 1 < max_weights * n_items :
+        if min_weights != max_weights:
             weight_capacity = np.random.randint(min_weights * n_items, max_weights * n_items)
         else:
             weight_capacity = np.random.randint(max_weights, max_weights * n_items)

--- a/openqaoa/problems/problem.py
+++ b/openqaoa/problems/problem.py
@@ -639,9 +639,15 @@ class Knapsack(Problem):
 
         values = list(map(int, np.random.randint(1, n_items, size=n_items)))
         weights = list(map(int, np.random.randint(1, n_items, size=n_items)))
-        weight_capacity = np.random.randint(np.min(weights) * n_items, np.max(weights) * n_items)
-        penalty = 2 * np.max(values)
 
+        min_weights = np.min(weights)
+        max_weights = np.max(weights)
+        if min_weights * n_items + 1 < max_weights * n_items :
+            weight_capacity = np.random.randint(min_weights * n_items, max_weights * n_items)
+        else:
+            weight_capacity = np.random.randint(max_weights, max_weights * n_items)
+        
+        penalty = 2 * np.max(values)
         return Knapsack(values, weights, weight_capacity, int(penalty))
 
     def terms_and_weights(self):
@@ -777,9 +783,15 @@ class SlackFreeKnapsack(Knapsack):
 
         values = list(map(int, np.random.randint(1, n_items, size=n_items)))
         weights = list(map(int, np.random.randint(1, n_items, size=n_items)))
-        weight_capacity = np.random.randint(np.min(weights) * n_items, np.max(weights) * n_items)
-        penalty = 2 * np.max(values)
 
+        min_weights = np.min(weights)
+        max_weights = np.max(weights)
+        if min_weights * n_items + 1 < max_weights * n_items :
+            weight_capacity = np.random.randint(min_weights * n_items, max_weights * n_items)
+        else:
+            weight_capacity = np.random.randint(max_weights, max_weights * n_items)
+        
+        penalty = 2 * np.max(values)
         return SlackFreeKnapsack(values, weights, weight_capacity, int(penalty))
     
     def terms_and_weights(self):

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -250,6 +250,26 @@ class TestProblem(unittest.TestCase):
         self.assertEqual(knap_manual.weights,knap_random_instance.weights)
         self.assertEqual(knap_manual.constant,knap_random_instance.constant)
         self.assertEqual(knap_manual.n,knap_random_instance.n)
+
+    def test_knapsack_random_problem_smallsize(self):
+        """Test random instance method of Knapsack problem class"""
+
+        np.random.seed(1234)
+        n_items = 3
+        values = list(map(int, np.random.randint(1, n_items, size=n_items)))
+        weights = list(map(int, np.random.randint(1, n_items, size=n_items)))
+        weight_capacity = np.random.randint(np.min(weights) * n_items, np.max(weights) * n_items)
+        penalty = 2*np.max(values)
+
+        knap_manual = Knapsack(values,weights,weight_capacity,int(penalty)).get_qubo_problem()
+
+        np.random.seed(1234)
+        knap_random_instance = Knapsack.random_instance(n_items=n_items).get_qubo_problem()
+
+        self.assertTrue(terms_list_equality(knap_manual.terms,knap_random_instance.terms))
+        self.assertEqual(knap_manual.weights,knap_random_instance.weights)
+        self.assertEqual(knap_manual.constant,knap_random_instance.constant)
+        self.assertEqual(knap_manual.n,knap_random_instance.n)
         
     def test_knapsack_type_checking(self):
         


### PR DESCRIPTION
## Description

`Knapsack` and `SlackFreeKnapsack` problem classes convert a Knapsack problem into a QUBO problem solvable using QAOA. They also include a `random_instance(n_items)` method to generate a problem randomly. This method failed in the case of the randomly generated list of item weights being all equal. 

This was due to `weight_capacity` selected randomly between `np.min(weights), np.max(weights)`. However, in the all-equal case, this statement breaks. The fix takes care of this edge case.

- **Fixes [#48](/entropicalabs/openqaoa/issues/48)**

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes.

[//]: <> (- [ ] Any dependent changes have been merged and published in downstream modules)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)