### PR TITLE
bugfix numeric angles need to be specified as RotationAngle objects too

### DIFF
--- a/openqaoa/qaoa_parameters/gatemap.py
+++ b/openqaoa/qaoa_parameters/gatemap.py
@@ -59,35 +59,54 @@ class SWAPGateMap(GateMap):
     @property
     def _decomposition_standard2(self) -> List[Tuple]:
 
-        return [(RZ, [self.qubit_1, np.pi/2]),
-                (RZ, [self.qubit_2, np.pi/2]),
+        return [(RZ, [self.qubit_1, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi/2)]),
+                (RZ, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi/2)]),
                 
                 # X gate decomposition
-                (RZ, [self.qubit_1, np.pi]),
-                (RX, [self.qubit_1, np.pi/2]),
-                (RZ, [self.qubit_1, np.pi]),
-                (RX, [self.qubit_1, -np.pi/2]),
+                (RZ, [self.qubit_1, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi)]),
+                (RX, [self.qubit_1, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi/2)]),
+                (RZ, [self.qubit_1, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi)]),
+                (RX, [self.qubit_1, RotationAngle(lambda x: x, self.pauli_label,
+                                                  -np.pi/2)]),
                 
                 # X gate decomposition
-                (RZ, [self.qubit_2, np.pi]),
-                (RX, [self.qubit_2, np.pi/2]),
-                (RZ, [self.qubit_2, np.pi]),
-                (RX, [self.qubit_2, -np.pi/2]),
+                (RZ, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi)]),
+                (RX, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi/2)]),
+                (RZ, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi)]),
+                (RX, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  -np.pi/2)]),
                 
-                (RiSWAP, [[self.qubit_1, self.qubit_2, np.pi]]),
+                (RiSWAP, [[self.qubit_1, self.qubit_2,
+                            RotationAngle(lambda x: x, self.pauli_label,np.pi)]]),
                 (CZ, [[self.qubit_1, self.qubit_2]]),
                 
                 # X gate decomposition
-                (RZ, [self.qubit_1, np.pi]),
-                (RX, [self.qubit_1, np.pi/2]),
-                (RZ, [self.qubit_1, np.pi]),
-                (RX, [self.qubit_1, -np.pi/2]),
+                (RZ, [self.qubit_1, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi)]),
+                (RX, [self.qubit_1, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi/2)]),
+                (RZ, [self.qubit_1, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi)]),
+                (RX, [self.qubit_1, RotationAngle(lambda x: x, self.pauli_label,
+                                                  -np.pi/2)]),
                 
                 # X gate decomposition
-                (RZ, [self.qubit_2, np.pi]),
-                (RX, [self.qubit_2, np.pi/2]),
-                (RZ, [self.qubit_2, np.pi]),
-                (RX, [self.qubit_2, -np.pi/2])]
+                (RZ, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi)]),
+                (RX, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi/2)]),
+                (RZ, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi)]),
+                (RX, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  -np.pi/2)])]
 
     
 class RotationGateMap(GateMap):
@@ -176,18 +195,26 @@ class RXXGateMap(TwoQubitRotationGateMap):
     @property
     def _decomposition_standard(self) -> List[Tuple]:
 
-        return [(RY, [self.qubit_1, np.pi/2]),
-                (RX, [self.qubit_1, np.pi]),
-                (RY, [self.qubit_2, np.pi/2]),
-                (RX, [self.qubit_2, np.pi]),
+        return [(RY, [self.qubit_1, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi/2)]),
+                (RX, [self.qubit_1, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi)]),
+                (RY, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi/2)]),
+                (RX, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi)]),
                 (CX, [[self.qubit_1, self.qubit_2]]),
                 (RZ, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
                                                   self.rotation_angle)]),
                 (CX, [[self.qubit_1, self.qubit_2]]),
-                (RY, [self.qubit_1, np.pi/2]),
-                (RX, [self.qubit_1, np.pi]),
-                (RY, [self.qubit_2, np.pi/2]),
-                (RX, [self.qubit_2, np.pi])]
+                (RY, [self.qubit_1, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi/2)]),
+                (RX, [self.qubit_1, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi)]),
+                (RY, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi/2)]),
+                (RX, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi)])]
 
 
 class RXYGateMap(TwoQubitRotationGateMap):
@@ -203,14 +230,18 @@ class RYYGateMap(TwoQubitRotationGateMap):
     @property
     def _decomposition_standard(self) -> List[Tuple]:
 
-        return [(RX, [self.qubit_1, np.pi/2]),
-                (RX, [self.qubit_2, np.pi/2]),
+        return [(RX, [self.qubit_1, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi/2)]),
+                (RX, [self.qubit_2,RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi/2)]),
                 (CX, [[self.qubit_1, self.qubit_2]]),
                 (RZ, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
                                                   self.rotation_angle)]),
                 (CX, [[self.qubit_1, self.qubit_2]]),
-                (RY, [self.qubit_2, -np.pi/2]),
-                (RX, [self.qubit_2, -np.pi/2])]
+                (RY, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  -np.pi/2)]),
+                (RX, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  -np.pi/2)])]
 
 
 class RZXGateMap(TwoQubitRotationGateMap):
@@ -218,14 +249,18 @@ class RZXGateMap(TwoQubitRotationGateMap):
     @property
     def _decomposition_standard(self) -> List[Tuple]:
 
-        return [(RY, [self.qubit_2, np.pi/2]),
-                (RX, [self.qubit_2, np.pi]),
+        return [(RY, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi/2)]),
+                (RX, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi)]),
                 (CX, [[self.qubit_1, self.qubit_2]]),
                 (RZ, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
                                                   self.rotation_angle)]),
                 (CX, [[self.qubit_1, self.qubit_2]]),
-                (RY, [self.qubit_2, np.pi/2]),
-                (RX, [self.qubit_2, np.pi])]
+                (RY, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi/2)]),
+                (RX, [self.qubit_2, RotationAngle(lambda x: x, self.pauli_label,
+                                                  np.pi)])]
 
 
 class RZZGateMap(TwoQubitRotationGateMap):


### PR DESCRIPTION
## Description

- Some fixed angles for the gates in GateMap decomposition are specified directly as numeric values. This breaks the code when these GateMap objects use any decomposition other than `trivial`. This can be quickly rectified by wrapping these numeric angles inside a RotationAngle object. This PR implements this fix

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings
- [ ] I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

[//]: <> (- [ ] Any dependent changes have been merged and published in downstream modules)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

