### PR TITLE
Dev parallelization

### DIFF
--- a/openqaoa/backends/qaoa_backend.py
+++ b/openqaoa/backends/qaoa_backend.py
@@ -43,7 +43,9 @@ def _backend_arg_mapper(backend_obj: QAOABaseBackend,
                         noise_model = None,
                         active_reset: Optional[bool] = None,
                         rewiring = None,
-                        qubit_layout = None):
+                        qubit_layout = None,
+                        unfence: Optional[bool] = None,
+                        trivial_parallelization: Optional[bool] = None):
 
     BACKEND_ARGS_MAPPER = {
         QAOAvectorizedBackendSimulator: {},
@@ -58,7 +60,9 @@ def _backend_arg_mapper(backend_obj: QAOABaseBackend,
         QAOAPyQuilQPUBackend: {'n_shots': n_shots,
                                'active_reset': active_reset,
                                'rewiring': rewiring,
-                               'qubit_layout':qubit_layout}
+                               'qubit_layout':qubit_layout,
+                               'unfence':unfence,
+                               'trivial_parallelization':trivial_parallelization}
     }
 
     final_backend_kwargs = {key: value for key, value in BACKEND_ARGS_MAPPER[backend_obj].items()


### PR DESCRIPTION
Addition of pyQuil-specific parallelization passes for QC runs:
1. Unfencing pass : allows 2Q gates to be executed in parallel by removing global fence statements (which are by default enabled)
2. trivial_parallelization pass: re-order pyQuil program according to 'trivial' commutation rules, i.e. re-arranging order of gates that act on independent sets of qubits.
3. [WIP] commutation_parallelization pass: re-order pyQuil program according to Pauli matrix commutation rules.