### PR TITLE
Bugfix: save_intermediate doesnt work for backends with no jobid

### DIFF
--- a/openqaoa/optimizers/training_vqa.py
+++ b/openqaoa/optimizers/training_vqa.py
@@ -232,8 +232,8 @@ class OptimizeVQA(ABC):
         if hasattr(self.vqa, 'job_id'):
             log_dict.update({'job_ids': self.vqa.job_id})
             
-        if self.save_to_csv:
-            save_parameter('job_ids', self.vqa.job_id)
+            if self.save_to_csv:
+                save_parameter('job_ids', self.vqa.job_id)
             
         self.log.log_variables(log_dict)
 

--- a/openqaoa/workflows/optimizer.py
+++ b/openqaoa/workflows/optimizer.py
@@ -324,13 +324,12 @@ class QAOA(Optimizer):
         self.backend = get_qaoa_backend(circuit_params=self.circuit_params,
                                         device=self.device,
                                         **self.backend_properties.__dict__)
-
         self.optimizer = get_optimizer(vqa_object=self.backend,
                                        variational_params=self.variate_params,
                                        optimizer_dict=self.classical_optimizer.asdict())
 
         self.compiled = True
-
+        
         if verbose:
             print('\t \033[1m ### Summary ###\033[0m')
             print(f'OpenQAOA has been compiled with the following properties')

--- a/openqaoa/workflows/optimizer.py
+++ b/openqaoa/workflows/optimizer.py
@@ -270,6 +270,8 @@ class QAOA(Optimizer):
                 Dictionary that specifies gradient-computation options according to method chosen in 'jac'.
             hess_options : dict
                 Dictionary that specifies Hessian-computation options according to method chosen in 'hess'.
+            save_intermediate: bool
+                If True, the intermediate parameters of the optimization and job ids, if available, are saved throughout the run. This is set to False by default.
         """
         for key, value in kwargs.items():
             if hasattr(self.classical_optimizer, key):

--- a/openqaoa/workflows/parameters/qaoa_parameters.py
+++ b/openqaoa/workflows/parameters/qaoa_parameters.py
@@ -288,7 +288,8 @@ class ClassicalOptimizer(Parameters):
                  hess_options: dict = None,
                  optimization_progress: bool = False,
                  cost_progress: bool = True,
-                 parameter_log: bool = True):
+                 parameter_log: bool = True, 
+                 save_intermediate: bool = False):
         self.optimize = optimize
         self.method = method.lower()
         self.maxiter = maxiter
@@ -305,6 +306,7 @@ class ClassicalOptimizer(Parameters):
         self.optimization_progress = optimization_progress
         self.cost_progress = cost_progress
         self.parameter_log = parameter_log
+        self.save_intermediate = save_intermediate
 
     # @property
     # def method(self):

--- a/openqaoa/workflows/parameters/qaoa_parameters.py
+++ b/openqaoa/workflows/parameters/qaoa_parameters.py
@@ -270,7 +270,8 @@ class ClassicalOptimizer(Parameters):
         Returns history of cost values if `True`. Defaults to `True`. 
     parameter_log : bool
         Returns history of angles if `True`. Defaults to `True`.
-
+    save_intermediate: bool
+        Outputs the jobids and parameters used for each circuit into seperate csv files. Defaults to `False`.
     """
 
     def __init__(self,


### PR DESCRIPTION
## Description

- Proper indentation to allow `save_intermediate` feature to be used in backends that have no job ids
- Add `save_intermediate` to the standard QAOA workflow
- Updated docstring for QAOA workflow class

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [x] I have performed a self-review of my code.
- [x] I have commented my code and used numpy-style docstrings
- [x] I have made corresponding updates to the documentation.
- [x] My changes generate no new warnings
- [x] I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

[//]: <> (- [ ] Any dependent changes have been merged and published in downstream modules)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

test_all.py
