### PR TITLE
hotfix for QPU access through QCS. 

### DIFF
--- a/openqaoa/backends/qpus/qaoa_pyquil_qpu.py
+++ b/openqaoa/backends/qpus/qaoa_pyquil_qpu.py
@@ -146,7 +146,7 @@ class QAOAPyQuilQPUBackend(QAOABaseBackendParametric, QAOABaseBackendCloud, QAOA
         """
         angles_list = np.array(self.obtain_angles_for_pauli_list(
             self.abstract_circuit, params), dtype=float)
-        angle_declarations = list(self.prog_exe.declarations.keys())
+        angle_declarations = list(self.parametric_circuit.declarations.keys())
         angle_declarations.remove('ro')
         for i, param_name in enumerate(angle_declarations):
             self.prog_exe.write_memory(


### PR DESCRIPTION


## Description

- Hotfix for Rigetti QPUs accessed through QCS.
- Retrieve declarations through `parametric_circuit` instead of `prog_exe` since EncryptedPrograms (generated by pyQuil only when using QPUs) do not have the `declarations` property.

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [x] I have performed a self-review of my code.
- [] I have commented my code and used numpy-style docstrings
- [ ] I have made corresponding updates to the documentation.
- [x] My changes generate no new warnings
- [ ] I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

[//]: <> (- [ ] Any dependent changes have been merged and published in downstream modules)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update