### PR TITLE
Hotfix for Rigetti QPUs accessed through QCS

### DIFF
--- a/openqaoa/backends/qpus/qaoa_pyquil_qpu.py
+++ b/openqaoa/backends/qpus/qaoa_pyquil_qpu.py
@@ -145,7 +145,7 @@ class QAOAPyQuilQPUBackend(QAOABaseBackendParametric, QAOABaseBackendCloud, QAOA
         """
         angles_list = np.array(self.obtain_angles_for_pauli_list(
             self.abstract_circuit, params), dtype=float)
-        angle_declarations = list(self.prog_exe.declarations.keys())
+        angle_declarations = list(self.parametric_circuit.declarations.keys())
         angle_declarations.remove('ro')
         for i, param_name in enumerate(angle_declarations):
             self.prog_exe.write_memory(


### PR DESCRIPTION
- Hotfix for Rigetti QPUs accessed through QCS.
- Retrieve declarations through parametric_circuit instead of prog_exe since EncryptedPrograms (generated by pyQuil only when using QPUs) do not have the declarations property.


## Description

- Please include a summary of the changes and the related issue
- Please also include relevant context.
- List any dependencies that are required for this change, if any.
- **Fixes # (issue)**

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [x ] I have performed a self-review of my code.
- [ ] I have commented my code and used numpy-style docstrings
- [ ] I have made corresponding updates to the documentation.
- [x ] My changes generate no new warnings
- [ ] I have added/updated tests to make sure bugfix/feature works.
- [ ] New and existing unit tests pass locally with my changes.

[//]: <> (- [ ] Any dependent changes have been merged and published in downstream modules)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Name the new unit-tests that you have added along with this change.
