### PR TITLE
Use sparse.linalg.expm for exponentiation of sparse matrices (for sci…

### DIFF
--- a/openqaoa/backends/simulators/qaoa_vectorized.py
+++ b/openqaoa/backends/simulators/qaoa_vectorized.py
@@ -20,7 +20,7 @@ from typing import Union, List, Tuple, Type, Optional
 import numpy as np
 from copy import copy
 from scipy.sparse import csc_matrix, kron, diags
-from scipy.linalg import expm
+from scipy.sparse.linalg import expm
 
 from ...basebackend import QAOABaseBackendStatevector, QuantumCircuitBase
 from ...qaoa_parameters.baseparams import QAOACircuitParams, QAOAVariationalBaseParams

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     "sympy>=1.10.1",
     "numpy>=1.22.3",
     "networkx>=2.8",
-    "scipy==1.8",
+    "scipy>=1.8",
     "matplotlib>=3.4.3, <3.5.0",
     "qiskit>=0.36.1",
     "pyquil>=3.1.0",


### PR DESCRIPTION
## Description
- test_vectorised.py was failing with scipy version 1.9 and later.
- this is because scipy 1.9 and onwards distinguishes between `sparse.linalg.expm` and `linalg.expm`
- the fix is backward compatible

- from scipy changelog : [scipy.linalg.expm (https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.expm.html#scipy.linalg.expm) due to historical reasons was using the sparse implementation and thus was accepting sparse arrays. Now it only works with nDarrays. For sparse usage, [scipy.sparse.linalg.expm](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.expm.html#scipy.sparse.linalg.expm) needs to be used explicitly.)

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [x] I have performed a self-review of my code.
- [] I have commented my code and used numpy-style docstrings
- [] I have made corresponding updates to the documentation.
- [x] My changes generate no new warnings
- [ ] I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

[//]: <> (- [ ] Any dependent changes have been merged and published in downstream modules)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Name the new unit-tests that you have added along with this change.
