### PR TITLE
Bugfix: Running .optimize() for a RQAOA object not working as expected

### DIFF
--- a/openqaoa/workflows/optimizer.py
+++ b/openqaoa/workflows/optimizer.py
@@ -684,6 +684,9 @@ class RQAOA(Optimizer):
         n_qubits = problem.n
         counter = self.rqaoa_parameters.counter 
 
+        # initialize the results object
+        self.results = RQAOAResults()
+
         # create a different max_terms function for each type 
         if self.rqaoa_parameters.rqaoa_type == "adaptive":
             f_max_terms = rqaoa.ada_max_terms  
@@ -692,6 +695,9 @@ class RQAOA(Optimizer):
 
         # If above cutoff, loop quantumly, else classically
         while n_qubits > n_cutoff:
+
+            # Compile qaoa with the problem
+            self._q.compile(problem, verbose=False)
 
             # Run QAOA
             self._q.optimize()
@@ -716,8 +722,7 @@ class RQAOA(Optimizer):
             qaoa_steps.append(copy.deepcopy(self._q))
             problem_steps.append(copy.deepcopy(new_problem))
 
-            # Compile qaoa with the new problem
-            self._q.compile(new_problem, verbose=False)
+            # problem is updated
             problem = new_problem
 
             # Add one step to the counter

--- a/openqaoa/workflows/optimizer.py
+++ b/openqaoa/workflows/optimizer.py
@@ -684,6 +684,9 @@ class RQAOA(Optimizer):
         n_qubits = problem.n
         counter = self.rqaoa_parameters.counter
 
+        # copy the original qaoa object
+        q = copy.deepcopy(self._q)
+
         # create a different max_terms function for each type 
         if self.rqaoa_parameters.rqaoa_type == "adaptive":
             f_max_terms = rqaoa.ada_max_terms  
@@ -693,11 +696,8 @@ class RQAOA(Optimizer):
         # If above cutoff, loop quantumly, else classically
         while n_qubits > n_cutoff:
 
-            # Compile qaoa with the problem
-            self._q.compile(problem, verbose=False)
-
             # Run QAOA
-            self._q.optimize()
+            q.optimize()
 
             # Obtain statistical results
             exp_vals_z, corr_matrix = self._exp_val_hamiltonian_termwise()
@@ -716,11 +716,14 @@ class RQAOA(Optimizer):
             n_qubits = new_problem.n
 
             # Save qaoa object and new problem
-            qaoa_steps.append(copy.deepcopy(self._q))
+            qaoa_steps.append(copy.deepcopy(q))
             problem_steps.append(copy.deepcopy(new_problem))
 
             # problem is updated
             problem = new_problem
+            
+            # Compile qaoa with the problem
+            q.compile(problem, verbose=False)
 
             # Add one step to the counter
             counter += 1

--- a/openqaoa/workflows/optimizer.py
+++ b/openqaoa/workflows/optimizer.py
@@ -700,7 +700,7 @@ class RQAOA(Optimizer):
             q.optimize()
 
             # Obtain statistical results
-            exp_vals_z, corr_matrix = self._exp_val_hamiltonian_termwise()
+            exp_vals_z, corr_matrix = self._exp_val_hamiltonian_termwise(q)
             # Retrieve highest expectation values according to adaptive method or schedule in custom method
             max_terms_and_stats = f_max_terms(exp_vals_z, corr_matrix, self._n_step(n_qubits, n_cutoff, counter))
             # Generate spin map
@@ -749,14 +749,12 @@ class RQAOA(Optimizer):
         return 
 
 
-    def _exp_val_hamiltonian_termwise(self):
+    def _exp_val_hamiltonian_termwise(self, q):
         """
         Private method to call the exp_val_hamiltonian_termwise function taking the data from
         the QAOA object _q. 
         It eturns what the exp_val_hamiltonian_termwise function returns.
         """
-
-        q = self._q
 
         variational_params = q.variate_params
         qaoa_backend = q.backend

--- a/openqaoa/workflows/optimizer.py
+++ b/openqaoa/workflows/optimizer.py
@@ -682,10 +682,7 @@ class RQAOA(Optimizer):
         problem = self.problem  
         n_cutoff = self.rqaoa_parameters.n_cutoff
         n_qubits = problem.n
-        counter = self.rqaoa_parameters.counter 
-
-        # initialize the results object
-        self.results = RQAOAResults()
+        counter = self.rqaoa_parameters.counter
 
         # create a different max_terms function for each type 
         if self.rqaoa_parameters.rqaoa_type == "adaptive":

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -655,6 +655,17 @@ class TestingRQAOA(unittest.TestCase):
 
         return r.results.get_solution()
 
+    def test_rqaoa_complie_multiple_times(self):
+        """
+        Test that the rqaoa can be compiled multiple times
+        """
+        graph = nw.circulant_graph(10, [1])
+        problem = MinimumVertexCover(graph, field=1, penalty=10).get_qubo_problem()
+
+        r = RQAOA()
+        r.compile(problem)
+        for _ in range(5): r.optimize()
+
     def test_example_1_adaptive_custom(self):
 
         # Number of qubits

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -655,7 +655,7 @@ class TestingRQAOA(unittest.TestCase):
 
         return r.results.get_solution()
 
-    def test_rqaoa_complie_multiple_times(self):
+    def test_rqaoa_compile_multiple_times(self):
         """
         Test that the rqaoa can be compiled multiple times
         """

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -655,7 +655,7 @@ class TestingRQAOA(unittest.TestCase):
 
         return r.results.get_solution()
 
-    def test_rqaoa_compile_multiple_times(self):
+    def test_rqaoa_optimize_multiple_times(self):
         """
         Test that the rqaoa can be compiled multiple times
         """


### PR DESCRIPTION
Before, if one optimized twice a RQAOA object, the second time wasn't working as expected. Because the self._q.was compiled with the last problem of the first optimization.  

## TODO
- [x] Every time that .optimize() is run the whole RQAOA process should restart
- [x] Check that now everything works as expected
- [x] Write some test that can check that this is the case
