### PR TITLE
fix: Spelling of Oxford Quantum Circuits

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Devices are serviced both locally and on the cloud. For the IBM Quantum experien
 | Device location  | Device Name |
 | ------------- | ------------- |
 | `local`  | `['qiskit.shot_simulator', 'qiskit.statevector_simulator', 'qiskit.qasm_simulator', 'vectorized', 'pyquil.statevector_simulator']`  |
-| [Amazon Braket](https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html)    | IonQ, Rigetti, OCQ, and simulators |
+| [Amazon Braket](https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html)    | IonQ, Rigetti, OQC, and simulators |
 | [IBMQ](https://quantum-computing.ibm.com/)    | Please check the IBMQ backends available to your account |
 | [Rigetti QCS](https://qcs.rigetti.com/sign-in)     | Aspen-11, Aspen-M-1, and QVM simulator |
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -123,7 +123,7 @@ Currently, the available devices are:
    * - `local`
      - `['qiskit_shot_simulator', 'qiskit_statevec_simulator', 'qiskit_qasm_simulator', 'vectorized', 'pyquil.statevector_simulator']`
    * - `Amazon Braket`
-     -  ['IonQ', 'Rigetti', 'OCQ']
+     -  ['IonQ', 'Rigetti', 'OQC']
    * - `IBMQ`
      - Please check the IBMQ backends available to your account
    * - `Rigetti's QCS`


### PR DESCRIPTION
Oxford Quantum Circuits was listed as OCQ instead of OQC.

## Description

Minor documentation fixes to correct spelling of Oxford Quantum Circuits, was listed as OCQ but should be OQC. No dependencies changed.

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [X] I have performed a self-review of my code.
- [N/A] I have commented my code and used numpy-style docstrings
- [N/A] I have made corresponding updates to the documentation.
- [X] My changes generate no new warnings
- [N/A] I have added/updated tests to make sure bugfix/feature works.
- [N/A] New and existing unit tests pass locally with my changes.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran `pytest tests/` and ensure test output was the same before and after the change.
