### PR TITLE
Changing data saving workflows methods

### DIFF
--- a/openqaoa/optimizers/result.py
+++ b/openqaoa/optimizers/result.py
@@ -111,7 +111,7 @@ class Result:
 
     #     return (string)
 
-    def asdict(self, keep_cost_hamiltonian:bool=True, complex_to_string:bool=False, exclude_keys:List[str]=[]):
+    def asdict(self, keep_cost_hamiltonian:bool=True, complex_to_string:bool=False, intermediate_mesurements:bool=True, exclude_keys:List[str]=[]):
         """
         Returns a dictionary with the results of the optimization, where the dictionary is serializable. 
         If the backend is a statevector backend, the measurement outcomes will be the statevector, meaning that it is a list of complex numbers, which is not serializable. If that is the case, and complex_to_string is true the complex numbers are converted to strings.
@@ -121,7 +121,10 @@ class Result:
         keep_cost_hamiltonian: `bool`
             If True, the cost hamiltonian is kept in the dictionary. If False, it is removed.
         complex_to_string: `bool`
-            If True, the complex numbers are converted to strings. If False, they are kept as complex numbers. This is useful for the JSON serialization.
+            If True, the complex numbers are converted to strings. If False, they are kept as complex numbers. This is useful for the JSON serialization. 
+        intermediate_mesurements: bool, optional
+            If True, intermediate measurements are included in the dump. If False, intermediate measurements are not included in the dump.
+            Default is True.
         exclude_keys: `list[str]`
             A list of keys to exclude from the returned dictionary.
 
@@ -143,7 +146,9 @@ class Result:
         if complex_to_string and issubclass(self.__backend, QAOABaseBackendStatevector):
             return_dict['intermediate'] = {}
             for key, value in self.intermediate.items():
-                if 'measurement' in key and (isinstance(value, list) or isinstance(value, np.ndarray)):
+                if intermediate_mesurements == False and 'measurement' in key: # if intermediate_mesurements is false, the intermediate measurements are not included in the dump
+                    return_dict['intermediate'][key] = []
+                elif 'measurement' in key and (isinstance(value, list) or isinstance(value, np.ndarray)):
                     return_dict['intermediate'][key] = [[complx_to_str(item) for item in list_] for list_ in value if (isinstance(list_, list) or isinstance(list_, np.ndarray))]
                 else:
                     return_dict['intermediate'][key] = value 

--- a/openqaoa/rqaoa/rqaoa_results.py
+++ b/openqaoa/rqaoa/rqaoa_results.py
@@ -22,7 +22,7 @@ class RQAOAResults(dict):
     It stores the results of the RQAOA optimization as a dictionary. With some custom methods.
     """
 
-    def asdict(self, keep_cost_hamiltonian:bool=True, complex_to_string:bool=False, exclude_keys:List[str]=[]):
+    def asdict(self, keep_cost_hamiltonian:bool=True, complex_to_string:bool=False, intermediate_mesurements:bool=True, exclude_keys:List[str]=[]):
         """
         Returns the results as a full dictionary, meaning that the objects of the intermediate steps are also converted to dictionaries.
 
@@ -31,9 +31,12 @@ class RQAOAResults(dict):
         keep_cost_hamiltonian : bool, optional
             If True, the cost Hamiltonian is kept in the dictionary, by default True.
         complex_to_string : bool, optional
-            If True, the complex numbers are converted to strings, by default False. This is useful for JSON serialization.
-        exclude_keys: `list[str]`
-            A list of keys to exclude from the returned dictionary.
+            If True, the complex numbers are converted to strings, by default False. This is useful for JSON serialization.    
+        intermediate_mesurements: bool, optional
+            If True, intermediate measurements are included in the dump. If False, intermediate measurements are not included in the dump.
+            Default is True.
+        exclude_keys: `list[str]`, optional
+            A list of keys to exclude from the returned dictionary.    
 
         Returns
         -------
@@ -45,8 +48,9 @@ class RQAOAResults(dict):
         results['intermediate_steps'] = []
         for step in self['intermediate_steps']:
             results['intermediate_steps'].append({
+                    'counter':      step['counter'],
                     'problem':      step['problem'].asdict(),
-                    'qaoa_results': step['qaoa_results'].asdict(keep_cost_hamiltonian=keep_cost_hamiltonian, complex_to_string=complex_to_string),
+                    'qaoa_results': step['qaoa_results'].asdict(keep_cost_hamiltonian, complex_to_string, intermediate_mesurements),
                     'exp_vals_z':   step['exp_vals_z'].tolist(),
                     'corr_matrix':  step['corr_matrix'].tolist(),
                 }) 

--- a/openqaoa/workflows/optimizer.py
+++ b/openqaoa/workflows/optimizer.py
@@ -18,6 +18,7 @@ import time
 import json
 from typing import List
 import gzip
+from os.path import exists
 
 from openqaoa.devices import DeviceLocal, DeviceBase
 from openqaoa.problems.problem import QUBO
@@ -297,7 +298,7 @@ class Optimizer(ABC):
     def optimize():
         raise NotImplementedError
 
-    def _serializable_dict(self, complex_to_string:bool=False):
+    def _serializable_dict(self, complex_to_string:bool=False, intermediate_mesurements:bool=True):
         """
         Returns a dictionary with all values and attributes of the object that we want to return in `asdict` and `dump(s)` methods in a dictionary.
         The returned dictionary has two keys: header and data. The header contains all the data that can identify the experiment, while the data contains all the input and output data of the experiment (also the experiment tags).
@@ -306,6 +307,9 @@ class Optimizer(ABC):
         ----------
         complex_to_string: bool
             If True, converts all complex numbers to strings. This is useful for JSON serialization, for the `dump(s)` methods.
+        intermediate_mesurements: bool
+            If True, intermediate measurements are included in the dump. If False, intermediate measurements are not included in the dump.
+            Default is True.
         """
         
         # create the final data dictionary
@@ -322,7 +326,7 @@ class Optimizer(ABC):
             if data['input_parameters']['backend_properties'][item] is not None:                                                                     
                 data['input_parameters']['backend_properties'][item] = str(data['input_parameters']['backend_properties'][item]) 
         
-        data['results'] = self.results.asdict(keep_cost_hamiltonian=False, complex_to_string=complex_to_string)
+        data['results'] = self.results.asdict(False, complex_to_string, intermediate_mesurements)
 
         # create the final header dictionary
         header = self.header.copy()
@@ -330,9 +334,9 @@ class Optimizer(ABC):
             **self.exp_tags.copy(),
             **{'problem_type': data['input_problem']['problem_instance']['problem_type']},
             **data['input_problem']['metadata'].copy(),
-            **{'backend_n_shots': data['input_parameters']['backend_properties']['n_shots'] },
-            **{'optimizer_'+key: data['input_parameters']['classical_optimizer'][key] 
-                                    for key in ['method', 'jac', 'hess'] 
+            **{'n_shots': data['input_parameters']['backend_properties']['n_shots'] },
+            **{prepend+key: data['input_parameters']['classical_optimizer'][key] 
+                                    for prepend, key in zip(['optimizer_', "", ""], ['method', 'jac', 'hess']) 
                                     if not data['input_parameters']['classical_optimizer'][key] is None}, 
         }   
 
@@ -344,25 +348,34 @@ class Optimizer(ABC):
 
         return serializable_dict
 
-    def asdict(self, exclude_keys:List[str]=[]):
+    def asdict(self, exclude_keys:List[str]=[], options:dict={}):
         """
         Returns a dictionary of the Optimizer object, where all objects are converted to dictionaries.
 
         Parameters
         ----------
         exclude_keys : List[str]
-            A list of keys to exclude from the returned dictionary.
+            A list of keys to exclude from the returned dictionary.         
+        options : dict
+            A dictionary of options to pass to the method that creates the dictionary to dump.
+            - complex_to_string : bool
+                If True, converts complex numbers to strings. If False, complex numbers are not converted to strings.
+            - intermediate_mesurements : bool
+                If True, includes the intermediate measurements in the results. If False, only the final measurements are included.
 
         Returns
         -------
         dict
         """
-        if exclude_keys == []:
-            return self._serializable_dict(complex_to_string=False)
-        else:
-            return delete_keys_from_dict(obj= self._serializable_dict(complex_to_string=False), keys_to_delete= exclude_keys)
 
-    def dumps(self, indent:int=2, exclude_keys:List[str]=[]):
+        options = {**{'complex_to_string': False}, **options}
+
+        if exclude_keys == []:
+            return self._serializable_dict(**options)
+        else:
+            return delete_keys_from_dict(obj= self._serializable_dict(**options), keys_to_delete= exclude_keys)
+
+    def dumps(self, indent:int=2, exclude_keys:List[str]=[], options:dict={}):
         """
         Returns a json string of the Optimizer object.
 
@@ -372,16 +385,22 @@ class Optimizer(ABC):
             The number of spaces to indent the result in the json file. If None, the result is not indented.
         exclude_keys : List[str]
             A list of keys to exclude from the json string.
+        options : dict
+            A dictionary of options to pass to the method that creates the dictionary to dump.
+            - intermediate_mesurements : bool
+                If True, includes the intermediate measurements in the results. If False, only the final measurements are included.
 
         Returns
         -------
         str
         """
 
+        options = {**options, **{'complex_to_string': True}}
+
         if exclude_keys == []:
-            return json.dumps(self._serializable_dict(complex_to_string=True), indent=indent)
+            return json.dumps(self._serializable_dict(**options), indent=indent)
         else:
-            return json.dumps(delete_keys_from_dict(obj= self._serializable_dict(complex_to_string=True), keys_to_delete= exclude_keys), indent=indent)
+            return json.dumps(delete_keys_from_dict(obj= self._serializable_dict(**options), keys_to_delete= exclude_keys), indent=indent)
 
     def dump(self, file_name:str = "", file_path:str="", prepend_id:bool=True, indent:int=2, compresslevel:int=0, exclude_keys:List[str]=[], overwrite:bool=False, options:dict={}):
         """
@@ -675,7 +694,7 @@ class QAOA(Optimizer):
             print(f'optimization completed.')
         return
 
-    def _serializable_dict(self, complex_to_string:bool = False): 
+    def _serializable_dict(self, complex_to_string:bool = False, intermediate_mesurements:bool = True): 
         """ 
         Returns all values and attributes of the object that we want to return in `asdict` and `dump(s)` methods in a dictionary.
 
@@ -688,21 +707,24 @@ class QAOA(Optimizer):
         -------
         serializable_dict: dict
             A dictionary containing all the values and attributes of the object that we want to return in `asdict` and `dump(s)` methods.
+        intermediate_mesurements: bool
+            If True, intermediate measurements are included in the dump. If False, intermediate measurements are not included in the dump.
+            Default is True.
         """
 
         # we call the _serializable_dict method of the parent class, specifying the keys to delete from the results dictionary
-        serializable_dict = super()._serializable_dict(complex_to_string=complex_to_string)
+        serializable_dict = super()._serializable_dict(complex_to_string, intermediate_mesurements)
 
         # we add the keys of the QAOA object that we want to return
         serializable_dict['data']['input_parameters']['circuit_properties'] = dict(self.circuit_properties)
 
         # include parameters in the header metadata
-        serializable_dict['header']['metadata']['circuit_param_type'] = serializable_dict['data']['input_parameters']['circuit_properties']['param_type']
-        serializable_dict['header']['metadata']['circuit_init_type'] = serializable_dict['data']['input_parameters']['circuit_properties']['init_type']
-        serializable_dict['header']['metadata']['circuit_p'] = serializable_dict['data']['input_parameters']['circuit_properties']['p']
+        serializable_dict['header']['metadata']['param_type'] = serializable_dict['data']['input_parameters']['circuit_properties']['param_type']
+        serializable_dict['header']['metadata']['init_type'] = serializable_dict['data']['input_parameters']['circuit_properties']['init_type']
+        serializable_dict['header']['metadata']['p'] = serializable_dict['data']['input_parameters']['circuit_properties']['p']
 
         if serializable_dict['data']['input_parameters']['circuit_properties']['q'] is not None:
-            serializable_dict['header']['metadata']['circuit_q'] = serializable_dict['data']['input_parameters']['circuit_properties']['q']
+            serializable_dict['header']['metadata']['q'] = serializable_dict['data']['input_parameters']['circuit_properties']['q']
 
         return serializable_dict
 
@@ -946,9 +968,11 @@ class RQAOA(Optimizer):
         self.__q.circuit_properties  = self.circuit_properties
         self.__q.backend_properties  = self.backend_properties
         self.__q.classical_optimizer = self.classical_optimizer
+        self.__q.exp_tags            = self.exp_tags
 
         # set the header of the qaoa object to be the same as the header of the rqaoa object
-        self.__q.header = self.header
+        self.__q.header = self.header.copy()
+        self.__q.header['algorithm'] = 'qaoa' # change the algorithm name to qaoa, since this is a qaoa object
 
         # compile qaoa object
         self.__q.compile(problem, verbose=verbose)
@@ -958,7 +982,7 @@ class RQAOA(Optimizer):
 
         return 
 
-    def optimize(self, verbose=False):
+    def optimize(self, dump:bool=False, dump_options:dict={}, verbose:bool=False):
         """
         Performs optimization using RQAOA with the `custom` method or the `adaptive` method.
         The elimination RQAOA loop will occur until the number of qubits is equal to the number of qubits specified in `n_cutoff`.
@@ -966,20 +990,33 @@ class RQAOA(Optimizer):
         and the QAOA will be recompiled with the new problem.
         Once the loop is complete, the final problem will be solved classically and the final solution will be reconstructed.
         Results will be stored in the `results` attribute.
+
+        Parameters
+        ----------
+        dump: `bool`
+            If true, the object will be dumped to a file. And at the end of each step, the qaoa object will be dumped to a file.
+            Default is False.
+        dump_options: `dict`
+            Dictionary containing the options for the dump. To see the options, see the `dump` method of the `QAOA` or `RQAOA` class.
+            Default is empty.
+        verbose: `bool`
+            TODO
         """
 
         #check if the object has been compiled (or already optimized)
         assert self.compiled, "RQAOA object has not been compiled. Please run the compile method first."
 
-        # lists to append the eliminations, the problems, the qaoa results objects, the correlation matrix and the expectation values z
+        # lists to append the eliminations, the problems, the qaoa results objects, the correlation matrix, the expectation values z and a dictionary for the atomic uuids
         elimination_tracker = []
         q_results_steps = []
         problem_steps = []
         exp_vals_z_steps = []
         corr_matrix_steps = []
+        atomic_uuid_steps = {}
 
         # get variables
         problem = self.problem  
+        problem_metadata = self.problem.metadata
         n_cutoff = self.rqaoa_parameters.n_cutoff
         n_qubits = problem.n
         counter = self.rqaoa_parameters.counter
@@ -999,11 +1036,14 @@ class RQAOA(Optimizer):
         # If above cutoff, loop quantumly, else classically
         while n_qubits > n_cutoff:
 
-            # Save the problem             
-            problem_steps.append(problem)
+            # put a tag to the qaoa object to know which step it is
+            q.set_exp_tags({'rqaoa_counter': counter})
 
             # Run QAOA
             q.optimize()
+
+            # save the results if dump is true
+            if dump: q.dump(**dump_options)
 
             # Obtain statistical results
             exp_vals_z, corr_matrix = self.__exp_val_hamiltonian_termwise(q)
@@ -1018,13 +1058,18 @@ class RQAOA(Optimizer):
             eliminations = [{'pair': (spin_map[spin][1],spin), 'correlation': spin_map[spin][0]} for spin in sorted(spin_map.keys()) if spin != spin_map[spin][1]]
             elimination_tracker.append(eliminations)
 
-            # Extract new number of qubits
-            n_qubits = new_problem.n
+            # add the metadata to the problem
+            new_problem.metadata = problem_metadata
 
             # Save qaoa object, correlation matrix and expectation values z
             q_results_steps.append(q.results)
             corr_matrix_steps.append(corr_matrix)
-            exp_vals_z_steps.append(exp_vals_z)
+            exp_vals_z_steps.append(exp_vals_z)                    
+            problem_steps.append(problem)
+            atomic_uuid_steps[counter] = q.header['atomic_uuid']
+
+            # Extract new number of qubits
+            n_qubits = new_problem.n
 
             # problem is updated
             problem = new_problem
@@ -1034,6 +1079,8 @@ class RQAOA(Optimizer):
 
             # Add one step to the counter
             counter += 1
+
+            # TODO: do rqaoa dumps here if dump is true, so that if the loop is interrupted, the user can still get the results
 
         # Solve the new problem classically
         cl_energy, cl_ground_states = ground_state_hamiltonian(problem.hamiltonian)
@@ -1050,11 +1097,15 @@ class RQAOA(Optimizer):
         self.results['classical_output'] = {'minimum_energy': cl_energy, 'optimal_states': cl_ground_states}
         self.results['elimination_rules'] = elimination_tracker
         self.results['schedule'] = [len(eliminations) for eliminations in elimination_tracker]
-        self.results['intermediate_steps'] = [{'problem': problem, 'qaoa_results': q_results, 'exp_vals_z': exp_vals_z, 'corr_matrix': corr_matrix} for problem, q_results, exp_vals_z, corr_matrix in zip(problem_steps, q_results_steps, exp_vals_z_steps, corr_matrix_steps)]
         self.results['number_steps'] = counter - self.rqaoa_parameters.counter 
+        self.results['intermediate_steps'] = [{'counter': counter, 'problem': problem, 'qaoa_results': q_results, 'exp_vals_z': exp_vals_z, 'corr_matrix': corr_matrix} for counter, problem, q_results, exp_vals_z, corr_matrix in zip(range(self.rqaoa_parameters.counter, counter), problem_steps, q_results_steps, exp_vals_z_steps, corr_matrix_steps)]
+        self.results['atomic_uuids'] = atomic_uuid_steps
 
         # set compiled to false
         self.compiled = False
+
+        # dump the object if dump is true
+        if dump: self.dump(**{**dump_options, **{'options':{'intermediate_mesurements': False}}})
 
         if verbose:
             print(f'RQAOA optimization completed.')
@@ -1097,7 +1148,7 @@ class RQAOA(Optimizer):
         # If the step eliminates more spins than available, reduce step to match cutoff
         return (n_qubits - n_cutoff) if (n_qubits - n_cutoff) < n else n
     
-    def _serializable_dict(self, complex_to_string:bool = False):
+    def _serializable_dict(self, complex_to_string:bool = False, intermediate_mesurements:bool = True):
         """
         Returns all values and attributes of the object that we want to return in `asdict` and `dump(s)` methods in a dictionary.
 
@@ -1110,21 +1161,24 @@ class RQAOA(Optimizer):
         -------
         serializable_dict: dict
             Dictionary containing all the values and attributes of the object that we want to return in `asdict` and `dump(s)` methods.
+        intermediate_mesurements: bool
+            If True, intermediate measurements are included in the dump. If False, intermediate measurements are not included in the dump.
+            Default is True.
         """
         # we call the _serializable_dict method of the parent class, specifying the keys to delete from the results dictionary
-        serializable_dict = super()._serializable_dict(complex_to_string=complex_to_string)
+        serializable_dict = super()._serializable_dict(complex_to_string, intermediate_mesurements)
 
         # we add the keys of the RQAOA object that we want to return
         serializable_dict['data']['input_parameters']['circuit_properties'] = dict(self.circuit_properties)
         serializable_dict['data']['input_parameters']['rqaoa_parameters'] = dict(self.rqaoa_parameters)
 
         # include parameters in the header metadata
-        serializable_dict['header']['metadata']['circuit_param_type'] = serializable_dict['data']['input_parameters']['circuit_properties']['param_type']
-        serializable_dict['header']['metadata']['circuit_init_type'] = serializable_dict['data']['input_parameters']['circuit_properties']['init_type']
-        serializable_dict['header']['metadata']['circuit_p'] = serializable_dict['data']['input_parameters']['circuit_properties']['p']
+        serializable_dict['header']['metadata']['param_type'] = serializable_dict['data']['input_parameters']['circuit_properties']['param_type']
+        serializable_dict['header']['metadata']['init_type'] = serializable_dict['data']['input_parameters']['circuit_properties']['init_type']
+        serializable_dict['header']['metadata']['p'] = serializable_dict['data']['input_parameters']['circuit_properties']['p']
 
         if serializable_dict['data']['input_parameters']['circuit_properties']['q'] is not None:
-            serializable_dict['header']['metadata']['circuit_q'] = serializable_dict['data']['input_parameters']['circuit_properties']['q']
+            serializable_dict['header']['metadata']['q'] = serializable_dict['data']['input_parameters']['circuit_properties']['q']
 
         serializable_dict['header']['metadata']['rqaoa_type'] = serializable_dict['data']['input_parameters']['rqaoa_parameters']['rqaoa_type']
         serializable_dict['header']['metadata']['rqaoa_n_max'] = serializable_dict['data']['input_parameters']['rqaoa_parameters']['n_max']

--- a/openqaoa/workflows/optimizer.py
+++ b/openqaoa/workflows/optimizer.py
@@ -261,6 +261,12 @@ class Optimizer(ABC):
                 Dictionary that specifies gradient-computation options according to method chosen in 'jac'.
             hess_options : dict
                 Dictionary that specifies Hessian-computation options according to method chosen in 'hess'.
+            optimization_progress : bool
+                Returns history of measurement outcomes/wavefunction if `True`. Defaults to `False`.
+            cost_progress : bool
+                Returns history of cost values if `True`. Defaults to `True`. 
+            parameter_log : bool
+                Returns history of angles if `True`. Defaults to `True`.
             save_intermediate: bool
                 If True, the intermediate parameters of the optimization and job ids, if available, are saved throughout the run. This is set to False by default.
         """
@@ -358,9 +364,9 @@ class Optimizer(ABC):
             A list of keys to exclude from the returned dictionary.         
         options : dict
             A dictionary of options to pass to the method that creates the dictionary to dump.
-            - complex_to_string : bool
+            complex_to_string : bool
                 If True, converts complex numbers to strings. If False, complex numbers are not converted to strings.
-            - intermediate_mesurements : bool
+            intermediate_mesurements : bool
                 If True, includes the intermediate measurements in the results. If False, only the final measurements are included.
 
         Returns
@@ -387,8 +393,8 @@ class Optimizer(ABC):
             A list of keys to exclude from the json string.
         options : dict
             A dictionary of options to pass to the method that creates the dictionary to dump.
-            - intermediate_mesurements : bool
-                If True, includes the intermediate measurements in the results. If False, only the final measurements are included.
+        intermediate_mesurements : bool
+            If True, includes the intermediate measurements in the results. If False, only the final measurements are included.
 
         Returns
         -------
@@ -424,8 +430,8 @@ class Optimizer(ABC):
             If True, overwrites the file if it already exists. If False, raises an error if the file already exists.
         options : dict
             A dictionary of options to pass to the method that creates the dictionary to dump.
-            - intermediate_mesurements : bool
-                If True, includes the intermediate measurements in the results. If False, only the final measurements are included.
+        intermediate_mesurements : bool
+            If True, includes the intermediate measurements in the results. If False, only the final measurements are included.
         """
 
         options = {**options, **{'complex_to_string': True}}
@@ -681,14 +687,14 @@ class QAOA(Optimizer):
             raise ValueError('Please compile the QAOA before optimizing it!')
 
         # timestamp for the start of the optimization
-        self.header['execution_time_start'] = int(time.time())
+        self.header['execution_time_start'] = time.time_ns()
 
         self.optimizer.optimize()
         # TODO: results and qaoa_results will differ
         self.results = self.optimizer.qaoa_result
 
         # timestamp for the end of the optimization
-        self.header['execution_time_end'] = int(time.time())
+        self.header['execution_time_end'] = time.time_ns()
 
         if verbose:
             print(f'optimization completed.')

--- a/openqaoa/workflows/optimizer.py
+++ b/openqaoa/workflows/optimizer.py
@@ -364,10 +364,10 @@ class Optimizer(ABC):
             A list of keys to exclude from the returned dictionary.         
         options : dict
             A dictionary of options to pass to the method that creates the dictionary to dump.
-            complex_to_string : bool
-                If True, converts complex numbers to strings. If False, complex numbers are not converted to strings.
-            intermediate_mesurements : bool
-                If True, includes the intermediate measurements in the results. If False, only the final measurements are included.
+                complex_to_string : bool
+                    If True, converts complex numbers to strings. If False, complex numbers are not converted to strings.
+                intermediate_mesurements : bool
+                    If True, includes the intermediate measurements in the results. If False, only the final measurements are included.
 
         Returns
         -------

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -762,6 +762,27 @@ class TestingVanillaQAOA(unittest.TestCase):
         except:
             error = True
         assert error, "Experiment tag keys should be strings."
+    
+    def test_qaoa_asdict_with_noise(self):
+        "test to check that we can serialize a QAOA object with noise"
+        device_backend = FakeVigo()
+        device = QasmSimulator.from_backend(device_backend)
+        noise_model = NoiseModel.from_backend(device)
+        q_noisy_shot = QAOA()
+
+        # device
+        qiskit_noisy_shot = create_device(location='local', name='qiskit.qasm_simulator')
+        q_noisy_shot.set_device(qiskit_noisy_shot)
+        # circuit properties
+        q_noisy_shot.set_circuit_properties(p=2, param_type='standard', init_type='rand', mixer_hamiltonian='x')
+        # backend properties
+        q_noisy_shot.set_backend_properties(n_shots = 200, noise_model = noise_model)
+        # classical optimizer properties
+        q_noisy_shot.set_classical_optimizer(method='COBYLA', maxiter=200,
+                                            cost_progress=True, parameter_log=True)
+        q_noisy_shot.compile(QUBO.random_instance(n=8))
+        q_noisy_shot.optimize()
+        q_noisy_shot.asdict()
 
     def test_qaoa_asdict_dumps(self):
         """Test the asdict method of the QAOA class."""
@@ -800,8 +821,8 @@ class TestingVanillaQAOA(unittest.TestCase):
 
         # check QAOA dump
         file_name = 'test_dump_qaoa.json'
-        uuid, project_uuid = qaoa.header['experiment_uuid'], qaoa.header['project_uuid']
-        full_name = f'{project_uuid}--{uuid}--{file_name}'
+        experiment_uuid, atomic_uuid = qaoa.header['experiment_uuid'], qaoa.header['atomic_uuid']
+        full_name = f'{experiment_uuid}--{atomic_uuid}--{file_name}'
 
         qaoa.dump(file_name, indent=None)
         assert os.path.isfile(full_name), 'Dump file does not exist'
@@ -809,12 +830,35 @@ class TestingVanillaQAOA(unittest.TestCase):
             assert file.read() == qaoa.dumps(indent=None), 'Dump file does not contain the correct data'
         os.remove(full_name)
 
-        # check QAOA dump when qaoa has no project_uuid
-        qaoa.header['project_uuid'] = None
-        full_name = f'{uuid}--{file_name}'
-        qaoa.dump(file_name, indent=None)
-        assert os.path.isfile(full_name), 'Dump file does not exist, when qaoa has no project_uuid'
-        os.remove(full_name)
+        # check RQAOA dump whitout prepending the experiment_uuid and atomic_uuid
+        qaoa.dump(file_name, indent=None,prepend_id=False)
+        assert os.path.isfile(file_name), 'Dump file does not exist, when not prepending the experiment_uuid and atomic_uuid'
+        
+        # check RQAOA dump fails when the file already exists
+        error = False
+        try:
+            qaoa.dump(file_name, indent=None,prepend_id=False)
+        except FileExistsError:
+            error = True
+        assert error, 'Dump file does not fail when the file already exists'
+
+        # check that we can overwrite the file
+        qaoa.dump(file_name, indent=None,prepend_id=False, overwrite=True)
+        assert os.path.isfile(file_name), 'Dump file does not exist, when overwriting'
+        os.remove(file_name)
+
+        # check RQAOA dump fails when prepend_id is True and file_name is not given
+        error = False
+        try:
+            qaoa.dump(prepend_id=False)
+        except ValueError:
+            error = True
+        assert error, 'Dump file does not fail when prepend_id is True and file_name is not given'
+
+        # check you can dump to a file with no arguments
+        qaoa.dump()
+        assert os.path.isfile(f'{experiment_uuid}--{atomic_uuid}.json'), 'Dump file does not exist, when no name is given'
+        os.remove(f'{experiment_uuid}--{atomic_uuid}.json')
 
         # check QAOA dump deleting some keys
         exclude_keys = ['schedule', 'pair']
@@ -831,26 +875,7 @@ class TestingVanillaQAOA(unittest.TestCase):
             assert file.read() == qaoa.dumps(indent=None).encode(), 'Dump file does not contain the correct data, when compressing'
         os.remove(full_name+'.gz')
 
-    def test_qaoa_asdict_with_noise(self):
-        "test to check that we can serialize a QAOA object with noise"
-        device_backend = FakeVigo()
-        device = QasmSimulator.from_backend(device_backend)
-        noise_model = NoiseModel.from_backend(device)
-        q_noisy_shot = QAOA()
-
-        # device
-        qiskit_noisy_shot = create_device(location='local', name='qiskit.qasm_simulator')
-        q_noisy_shot.set_device(qiskit_noisy_shot)
-        # circuit properties
-        q_noisy_shot.set_circuit_properties(p=2, param_type='standard', init_type='rand', mixer_hamiltonian='x')
-        # backend properties
-        q_noisy_shot.set_backend_properties(n_shots = 200, noise_model = noise_model)
-        # classical optimizer properties
-        q_noisy_shot.set_classical_optimizer(method='COBYLA', maxiter=200,
-                                            cost_progress=True, parameter_log=True)
-        q_noisy_shot.compile(QUBO.random_instance(n=8))
-        q_noisy_shot.optimize()
-        q_noisy_shot.asdict()
+        
         
     def __test_expected_keys(self, obj, exclude_keys=[], method='asdict'):
         """
@@ -858,7 +883,7 @@ class TestingVanillaQAOA(unittest.TestCase):
         """
 
         #create a dictionary with all the expected keys and set them to False
-        expected_keys = ['header', 'atomic_uuid', 'experiment_uuid', 'project_uuid', 'algorithm', 'name', 'run_by', 'provider', 'target', 'cloud', 'client', 'qubit_number', 'qubit_routing', 'error_mitigation', 'error_correction', 'execution_time_start', 'execution_time_end', 'metadata', 'data', 'exp_tags', 'input_problem', 'terms', 'weights', 'constant', 'n', 'problem_instance', 'problem_type', 'input_parameters', 'device', 'device_location', 'device_name', 'backend_properties', 'init_hadamard', 'n_shots', 'prepend_state', 'append_state', 'cvar_alpha', 'noise_model', 'qubit_layout', 'seed_simulator', 'qiskit_simulation_method', 'active_reset', 'rewiring', 'disable_qubit_rewiring', 'classical_optimizer', 'optimize', 'method', 'maxiter', 'maxfev', 'jac', 'hess', 'constraints', 'bounds', 'tol', 'optimizer_options', 'jac_options', 'hess_options', 'parameter_log', 'optimization_progress', 'cost_progress', 'save_intermediate', 'circuit_properties', 'param_type', 'init_type', 'qubit_register', 'p', 'q', 'variational_params_dict', 'total_annealing_time', 'annealing_time', 'linear_ramp_time', 'mixer_hamiltonian', 'mixer_qubit_connectivity', 'mixer_coeffs', 'seed', 'results', 'evals', 'number_of_evals', 'jac_evals', 'qfim_evals', 'most_probable_states', 'solutions_bitstrings', 'bitstring_energy', 'intermediate', 'angles', 'cost', 'measurement_outcomes', 'job_id', 'optimized', 'angles', 'cost', 'measurement_outcomes', 'job_id']
+        expected_keys = ['header', 'atomic_uuid', 'experiment_uuid', 'project_uuid', 'algorithm', 'name', 'run_by', 'provider', 'target', 'cloud', 'client', 'qubit_number', 'qubit_routing', 'error_mitigation', 'error_correction', 'execution_time_start', 'execution_time_end', 'metadata', 'problem_type', 'n_shots', 'optimizer_method', 'param_type', 'init_type', 'p', 'data', 'exp_tags', 'input_problem', 'terms', 'weights', 'constant', 'n', 'problem_instance', 'input_parameters', 'device', 'device_location', 'device_name', 'backend_properties', 'init_hadamard', 'prepend_state', 'append_state', 'cvar_alpha', 'noise_model', 'qubit_layout', 'seed_simulator', 'qiskit_simulation_method', 'active_reset', 'rewiring', 'disable_qubit_rewiring', 'classical_optimizer', 'optimize', 'method', 'maxiter', 'maxfev', 'jac', 'hess', 'constraints', 'bounds', 'tol', 'optimizer_options', 'jac_options', 'hess_options', 'parameter_log', 'optimization_progress', 'cost_progress', 'save_intermediate', 'circuit_properties', 'qubit_register', 'q', 'variational_params_dict', 'total_annealing_time', 'annealing_time', 'linear_ramp_time', 'mixer_hamiltonian', 'mixer_qubit_connectivity', 'mixer_coeffs', 'seed', 'results', 'evals', 'number_of_evals', 'jac_evals', 'qfim_evals', 'most_probable_states', 'solutions_bitstrings', 'bitstring_energy', 'intermediate', 'angles', 'cost', 'measurement_outcomes', 'job_id', 'optimized', 'eval_number']
         expected_keys = {item: False for item in expected_keys}
 
         #test the keys, it will set the keys to True if they are found
@@ -1147,8 +1172,8 @@ class TestingRQAOA(unittest.TestCase):
 
         # check RQAOA dump
         file_name = 'test_dump_rqaoa.json'
-        uuid, project_uuid = rqaoa.header['experiment_uuid'], rqaoa.header['project_uuid']
-        full_name = f'{project_uuid}--{uuid}--{file_name}'
+        experiment_uuid, atomic_uuid = rqaoa.header['experiment_uuid'], rqaoa.header['atomic_uuid']
+        full_name = f'{experiment_uuid}--{atomic_uuid}--{file_name}'
 
         rqaoa.dump(file_name, indent=None)
         assert os.path.isfile(full_name), 'Dump file does not exist'
@@ -1156,12 +1181,35 @@ class TestingRQAOA(unittest.TestCase):
             assert file.read() == rqaoa.dumps(indent=None), 'Dump file does not contain the correct data'
         os.remove(full_name)
 
-        # check RQAOA dump when rqaoa has no project_uuid
-        rqaoa.header['project_uuid'] = None
-        full_name = f'{uuid}--{file_name}'
-        rqaoa.dump(file_name, indent=None)
-        assert os.path.isfile(full_name), 'Dump file does not exist, when rqaoa has no project_uuid'
-        os.remove(full_name)
+        # check RQAOA dump whitout prepending the experiment_uuid and atomic_uuid
+        rqaoa.dump(file_name, indent=None,prepend_id=False)
+        assert os.path.isfile(file_name), 'Dump file does not exist, when not prepending the experiment_uuid and atomic_uuid'
+        
+        # check RQAOA dump fails when the file already exists
+        error = False
+        try:
+            rqaoa.dump(file_name, indent=None,prepend_id=False)
+        except FileExistsError:
+            error = True
+        assert error, 'Dump file does not fail when the file already exists'
+
+        # check that we can overwrite the file
+        rqaoa.dump(file_name, indent=None,prepend_id=False, overwrite=True)
+        assert os.path.isfile(file_name), 'Dump file does not exist, when overwriting'
+        os.remove(file_name)
+
+        # check RQAOA dump fails when prepend_id is True and file_name is not given
+        error = False
+        try:
+            rqaoa.dump(prepend_id=False)
+        except ValueError:
+            error = True
+        assert error, 'Dump file does not fail when prepend_id is True and file_name is not given'
+
+        # check you can dump to a file with no arguments
+        rqaoa.dump()
+        assert os.path.isfile(f'{experiment_uuid}--{atomic_uuid}.json'), 'Dump file does not exist, when no name is given'
+        os.remove(f'{experiment_uuid}--{atomic_uuid}.json')
 
         # check RQAOA dump deleting some keys
         exclude_keys = ['schedule', 'pair']
@@ -1185,7 +1233,7 @@ class TestingRQAOA(unittest.TestCase):
         """
 
         #create a dictionary with all the expected keys and set them to False
-        expected_keys = ['header', 'atomic_uuid', 'experiment_uuid', 'project_uuid', 'algorithm', 'name', 'run_by', 'provider', 'target', 'cloud', 'client', 'qubit_number', 'qubit_routing', 'error_mitigation', 'error_correction', 'execution_time_start', 'execution_time_end', 'metadata', 'tag1', 'tag2', 'data', 'exp_tags', 'input_problem', 'terms', 'weights', 'constant', 'n', 'problem_instance', 'problem_type', 'input_parameters', 'device', 'device_location', 'device_name', 'backend_properties', 'init_hadamard', 'n_shots', 'prepend_state', 'append_state', 'cvar_alpha', 'noise_model', 'qubit_layout', 'seed_simulator', 'qiskit_simulation_method', 'active_reset', 'rewiring', 'disable_qubit_rewiring', 'classical_optimizer', 'optimize', 'method', 'maxiter', 'maxfev', 'jac', 'hess', 'constraints', 'bounds', 'tol', 'optimizer_options', 'jac_options', 'hess_options', 'parameter_log', 'optimization_progress', 'cost_progress', 'save_intermediate', 'circuit_properties', 'param_type', 'init_type', 'qubit_register', 'p', 'q', 'variational_params_dict', 'total_annealing_time', 'annealing_time', 'linear_ramp_time', 'mixer_hamiltonian', 'mixer_qubit_connectivity', 'mixer_coeffs', 'seed', 'rqaoa_parameters', 'rqaoa_type', 'n_max', 'steps', 'n_cutoff', 'original_hamiltonian', 'counter', 'results', 'solution', 'classical_output', 'minimum_energy', 'optimal_states', 'elimination_rules', 'pair', 'correlation', 'schedule', 'intermediate_steps', 'problem', 'qaoa_results', 'evals', 'number_of_evals', 'jac_evals', 'qfim_evals', 'most_probable_states', 'solutions_bitstrings', 'bitstring_energy', 'intermediate', 'angles', 'cost', 'measurement_outcomes', 'job_id', 'optimized', 'angles', 'cost', 'measurement_outcomes', 'job_id', 'exp_vals_z', 'corr_matrix', 'number_steps']
+        expected_keys = ['header', 'atomic_uuid', 'experiment_uuid', 'project_uuid', 'algorithm', 'name', 'run_by', 'provider', 'target', 'cloud', 'client', 'qubit_number', 'qubit_routing', 'error_mitigation', 'error_correction', 'execution_time_start', 'execution_time_end', 'metadata', 'tag1', 'tag2', 'problem_type', 'n_shots', 'optimizer_method', 'param_type', 'init_type', 'p', 'rqaoa_type', 'rqaoa_n_max', 'rqaoa_n_cutoff', 'data', 'exp_tags', 'input_problem', 'terms', 'weights', 'constant', 'n', 'problem_instance', 'input_parameters', 'device', 'device_location', 'device_name', 'backend_properties', 'init_hadamard', 'prepend_state', 'append_state', 'cvar_alpha', 'noise_model', 'qubit_layout', 'seed_simulator', 'qiskit_simulation_method', 'active_reset', 'rewiring', 'disable_qubit_rewiring', 'classical_optimizer', 'optimize', 'method', 'maxiter', 'maxfev', 'jac', 'hess', 'constraints', 'bounds', 'tol', 'optimizer_options', 'jac_options', 'hess_options', 'parameter_log', 'optimization_progress', 'cost_progress', 'save_intermediate', 'circuit_properties', 'qubit_register', 'q', 'variational_params_dict', 'total_annealing_time', 'annealing_time', 'linear_ramp_time', 'mixer_hamiltonian', 'mixer_qubit_connectivity', 'mixer_coeffs', 'seed', 'rqaoa_parameters', 'n_max', 'steps', 'n_cutoff', 'original_hamiltonian', 'counter', 'results', 'solution', 'classical_output', 'minimum_energy', 'optimal_states', 'elimination_rules', 'pair', 'correlation', 'schedule', 'number_steps', 'intermediate_steps', 'problem', 'qaoa_results', 'evals', 'number_of_evals', 'jac_evals', 'qfim_evals', 'most_probable_states', 'solutions_bitstrings', 'bitstring_energy', 'intermediate', 'angles', 'cost', 'measurement_outcomes', 'job_id', 'optimized', 'eval_number', 'exp_vals_z', 'corr_matrix', 'atomic_uuids']
         expected_keys = {item: False for item in expected_keys}
 
         #test the keys, it will set the keys to True if they are found
@@ -1220,7 +1268,80 @@ class TestingRQAOA(unittest.TestCase):
             print(expected_keys)
         """
 
+    def test_rqaoa_dumping_step_by_step(self):
+        """
+        test dumping the RQAOA object step by step
+        """
+        
+        # define the problem
+        problem = QUBO.random_instance(n=8)
+        problem.set_metadata({'metadata_key1': 'metadata_value1', 'metadata_key2': 'metadata_value2'})
 
+        # define the RQAOA object
+        r = RQAOA()
+
+        # set experimental tags
+        r.set_exp_tags({'tag1': 'value1', 'tag2': 'value2'})
+
+        # set the classical optimizer
+        r.set_classical_optimizer(optimization_progress=True)  
+
+        # compile the problem
+        r.compile(problem)
+
+        # optimize the problem while dumping the data at each step
+        r.optimize(dump=True, dump_options={'file_name': 'test_dumping_step_by_step', 'compresslevel': 2, 'indent': None})
+
+        # create list of expected file names
+        experiment_uuid, atomic_uuid = r.header['experiment_uuid'], r.header['atomic_uuid']
+        file_names = {uuid: experiment_uuid + '--' + uuid + '--' + 'test_dumping_step_by_step.json.gz' for uuid in r.results['atomic_uuids'].values()}
+        file_names[atomic_uuid] = experiment_uuid + '--' + atomic_uuid + '--' + 'test_dumping_step_by_step.json.gz'
+
+        # check if the files exist
+        for file_name in file_names.values():
+            assert os.path.isfile(file_name), f'File {file_name} does not exist.'
+
+        # put each file in a dictionary
+        files = {}
+        for atomic_uuid, file_name in file_names.items():
+            with gzip.open(file_name, 'rb') as file:
+                files[atomic_uuid] = json.loads(file.read().decode())
+
+        rqaoa_files, qaoa_files = 0, 0
+                
+        # check if the files have the expected keys
+        for atomic_uuid, dictionary in files.items():
+
+            file_name = file_names[atomic_uuid]
+
+            if r.header['atomic_uuid'] == atomic_uuid: # rqaoa files
+
+                rqaoa_files += 1
+
+                assert dictionary['header']['experiment_uuid'] == r.header['experiment_uuid'], f'File {file_name} has a different experiment_uuid than the RQAOA object.'
+                assert dictionary['header']['atomic_uuid'] == r.header['atomic_uuid'], f'File {file_name} has a different atomic_uuid than the RQAOA object.'
+                assert dictionary['header']['algorithm'] == 'rqaoa', f'File {file_name} has a different algorithm than rqaoa, which is the expected algorithm.'
+
+                #check that the intermediate mesuraments are empty
+                for step in dictionary['data']['results']['intermediate_steps']:
+                    assert step['qaoa_results']['intermediate']['measurement_outcomes'] == [], f'File {file_name} has intermediate mesuraments, but it should not have them.'
+            
+            else: # qaoa files
+
+                qaoa_files += 1
+
+                assert dictionary['header']['atomic_uuid'] == atomic_uuid, f'File {file_name} has a different atomic_uuid than expected.'
+                assert dictionary['header']['algorithm'] == 'qaoa', f'File {file_name} has a different algorithm than qaoa, which is the expected algorithm.'
+
+                #check that the intermediate mesuraments are not empty
+                assert len(dictionary['data']['results']['intermediate']['measurement_outcomes']) > 0, f'File {file_name} does not have intermediate mesuraments, but it should have them.'
+
+        assert rqaoa_files == 1, f'Expected 1 rqaoa file, but {rqaoa_files} were found.'
+        assert qaoa_files == len(r.results['atomic_uuids']), f'Expected {len(r.results["atomic_uuids"])} qaoa files, but {qaoa_files} were found.'
+
+        # erease the files
+        for file_name in file_names.values():
+            os.remove(file_name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In this PR changes to the dump(s) methods and the way we save the data/files will be implemented.


The header has been already changed, now when we dump the data we find something like:
```
'header'{
 ...,
 'metadata': {'tag1': 'value1',
   'tag2': 'value2',
   'problem_type': 'maximum_cut',
   'key1': 'value1',
   'key2': 'value2',
   'backend_n_shots': 100,
   'optimizer_method': 'nelder-mead',
   'optimizer_jac': 'finite_difference',
   'optimizer_hess': 'finite_difference',
   'circuit_param_type': 'standard',
   'circuit_init_type': 'rand',
   'circuit_p': 2,
   'rqaoa_type': 'adaptive',
   'rqaoa_n_max': 1,
   'rqaoa_n_cutoff': 3}
}
```