### PR TITLE
Fix warning: invalid location

### DIFF
--- a/src/openqaoa-core/backends/qaoa_device.py
+++ b/src/openqaoa-core/backends/qaoa_device.py
@@ -57,6 +57,13 @@ def device_class_arg_mapper(
     }
     return final_device_kwargs
 
+LOCATION_MAPPER = {
+    "ibmq": DeviceQiskit,
+    "qcs": DevicePyquil,
+    "aws": DeviceAWS,
+    "local": DeviceLocal,
+    "azure": DeviceAzure,
+}
 
 def create_device(location: str, name: str, **kwargs):
     """
@@ -78,17 +85,9 @@ def create_device(location: str, name: str, **kwargs):
         An instance of the appropriate device class.
     """
     location = location.lower()
-    if location == "ibmq":
-        device_class = DeviceQiskit
-    elif location == "qcs":
-        device_class = DevicePyquil
-    elif location == "aws":
-        device_class = DeviceAWS
-    elif location == "local":
-        device_class = DeviceLocal
-    elif location == "azure":
-        device_class = DeviceAzure
-    else:
-        raise ValueError(f"Invalid device location, Choose from: {location}")
+    if location not in LOCATION_MAPPER:
+        raise ValueError(f"Invalid device location, Choose from: {list(LOCATION_MAPPER.keys())}")
+    
+    device_class = LOCATION_MAPPER[location]
 
     return device_class(device_name=name, **kwargs)

--- a/src/openqaoa-core/backends/qaoa_device.py
+++ b/src/openqaoa-core/backends/qaoa_device.py
@@ -6,7 +6,6 @@ from openqaoa_qiskit.backends import DeviceQiskit
 from openqaoa_pyquil.backends import DevicePyquil
 from openqaoa_azure.backends import DeviceAzure
 
-
 def device_class_arg_mapper(
     device_class: DeviceBase,
     hub: str = None,


### PR DESCRIPTION
## Description

Before when running:
``
device = create_device(location='test', name='vectorized')
``
you got a warning like:
> _Invalid device location, Choose from: 'test'_

it was returning the input.

I have modified that so that the warning that you get is:
> _Invalid device location, Choose from: ['ibmq', 'qcs', 'aws', 'local', 'azure']_
