### PR TITLE
Bug Fix: Added missing constant term contribution in energy_expectation

### DIFF
--- a/src/openqaoa-core/utilities.py
+++ b/src/openqaoa-core/utilities.py
@@ -748,6 +748,9 @@ def energy_expectation(hamiltonian: Hamiltonian, measurement_counts: dict) -> fl
     # Normalize with respect to the number of shots
     energy *= 1 / shots
 
+    # Add constant term in Hamiltonian
+    energy += hamiltonian.constant
+
     return energy
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -508,15 +508,18 @@ class TestingUtilities(unittest.TestCase):
         and a given measurement counts dictionary.
         """
 
+        ## First test - Ring of Disagrees
+
         # Number of qubits
         n_qubits = 10
 
         # Define edges and weights determining the problem graph
         edges = [(i, i + 1) for i in range(n_qubits - 1)] + [(0, n_qubits - 1)]
         weights = [1 for _ in range(len(edges))]
+        constant = 10
 
         # Hamiltonian
-        hamiltonian = Hamiltonian.classical_hamiltonian(edges, weights, constant=0)
+        hamiltonian = Hamiltonian.classical_hamiltonian(edges, weights, constant)
 
         # Input measurement counts dictionary
         input_measurement_counts = {
@@ -531,12 +534,49 @@ class TestingUtilities(unittest.TestCase):
         energy = energy_expectation(hamiltonian, input_measurement_counts)
 
         # Correct energy
-        correct_energy = 1.2
+        correct_energy = 11.2
 
         # Test energy was computed correctly
-        assert np.allclose(
-            energy, correct_energy
-        ), f"The energy expectation value was not computed correctly"
+        assert np.allclose(energy, correct_energy), f"The energy expectation value for rings of disagrees was not computed correctly"
+
+
+        ## Second test - Minimum Vertex Cover on a Ring
+
+        # Number of qubits
+        n_qubits = 10
+
+        # Edges of the graph
+        edges = [(i, i + 1) for i in range(n_qubits - 1)] + [(0, n_qubits - 1)]
+
+        # Define graph and add edges
+        G = nx.Graph()
+        G.add_edges_from(edges)
+
+        # QUBO instance of the problem
+        field = 1.0
+        penalty = 10.0
+        mvc = MinimumVertexCover(G, field=field, penalty=penalty).qubo
+
+        # Minimum Vertex Cover Hamiltonian
+        hamiltonian = Hamiltonian.classical_hamiltonian(mvc.terms, mvc.weights, mvc.constant)
+
+        # Input measurement counts dictionary
+        input_measurement_counts = {
+            "0101010101": 10,
+            "1010101010": 10,
+            "0000000000": 10,
+            "1111111111": 10,
+        }
+
+        # Obtain energy expectation value
+        energy = energy_expectation(hamiltonian, input_measurement_counts)
+
+        # Correct energy
+        correct_energy = 30
+
+        # Test energy was computed correctly
+        assert np.allclose(energy, correct_energy), f"The energy expectation value for Minimum Vertex Cover was not computed correctly"
+
 
     def test_energy_spectrum_hamiltonian(self):
         """


### PR DESCRIPTION
## Description

The energy_expectation() function in utilities.oy did not account for constant terms, and the respective test wasa ring of disagrees Hamiltonian with vanishing constant.

I have fixed the issue by adding the constant after the averaging, I have modified the current test by adding a constant term to the ring of disagrees Hamiltonian and added a second test on a Minimum Vertex Cover Hamiltonian.

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [x] I have performed a self-review of my code.
- [x] I have commented my code and used numpy-style docstrings
- [x] I have made corresponding updates to the documentation.
- [x] My changes generate no new warnings
- [x] I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

[//]: <> (- [ ] Any dependent changes have been merged and published in downstream modules)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Modified test_utilities.py as per in the description
