### PR TITLE
fixed file name dump method workflows

### DIFF
--- a/src/openqaoa-core/algorithms/baseworkflow.py
+++ b/src/openqaoa-core/algorithms/baseworkflow.py
@@ -479,7 +479,7 @@ class Workflow(ABC):
         self,
         file_name: str = "",
         file_path: str = "",
-        prepend_id: bool = True,
+        prepend_id: bool = False,
         indent: int = 2,
         compresslevel: int = 0,
         exclude_keys: List[str] = [],
@@ -497,6 +497,10 @@ class Workflow(ABC):
             The name of the json file.
         file_path : str
             The path where the json file will be saved.
+        prepend_id : bool
+            If True, the name will have the following format: '{project_id}--{experiment_id}--{atomic_id}--{file_name}.json'.
+            If False, the name will have the following format: '{file_name}.json'.
+            Default is False.
         indent : int
             The number of spaces to indent the result in the json file.
             If None, the result is not indented.
@@ -522,7 +526,7 @@ class Workflow(ABC):
 
         # get the full name
         if prepend_id == False and file_name == "":
-            raise ValueError("If prepend_id is False, file_name must be specified.")
+            raise ValueError("dump method missing argument: 'file_name'. Otherwise 'prepend_id' must be specified as True.")
         elif prepend_id == False:
             file = file_path + file_name
         elif file_name == "":

--- a/src/openqaoa-core/algorithms/baseworkflow.py
+++ b/src/openqaoa-core/algorithms/baseworkflow.py
@@ -518,6 +518,8 @@ class Workflow(ABC):
 
         options = {**options, **{"complex_to_string": True}}
 
+        project_id = self.header["project_id"] if not self.header["project_id"] is None else "None"
+
         # get the full name
         if prepend_id == False and file_name == "":
             raise ValueError("If prepend_id is False, file_name must be specified.")
@@ -526,6 +528,8 @@ class Workflow(ABC):
         elif file_name == "":
             file = (
                 file_path
+                + project_id
+                + "--"
                 + self.header["experiment_id"]
                 + "--"
                 + self.header["atomic_id"]
@@ -533,6 +537,8 @@ class Workflow(ABC):
         else:
             file = (
                 file_path
+                + project_id
+                + "--"
                 + self.header["experiment_id"]
                 + "--"
                 + self.header["atomic_id"]

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1005,7 +1005,7 @@ class TestingVanillaQAOA(unittest.TestCase):
         )
         full_name = f"{project_id}--{experiment_id}--{atomic_id}--{file_name}"
 
-        qaoa.dump(file_name, indent=None)
+        qaoa.dump(file_name, indent=None, prepend_id=True)
         assert os.path.isfile(full_name), "Dump file does not exist"
         with open(full_name, "r") as file:
             assert file.read() == qaoa.dumps(
@@ -1013,13 +1013,13 @@ class TestingVanillaQAOA(unittest.TestCase):
             ), "Dump file does not contain the correct data"
         os.remove(full_name)
 
-        # check RQAOA dump whitout prepending the experiment_id and atomic_id
+        # check QAOA dump whitout prepending the experiment_id and atomic_id
         qaoa.dump(file_name, indent=None, prepend_id=False)
         assert os.path.isfile(
             file_name
         ), "Dump file does not exist, when not prepending the experiment_id and atomic_id"
 
-        # check RQAOA dump fails when the file already exists
+        # check QAOA dump fails when the file already exists
         error = False
         try:
             qaoa.dump(file_name, indent=None, prepend_id=False)
@@ -1032,7 +1032,7 @@ class TestingVanillaQAOA(unittest.TestCase):
         assert os.path.isfile(file_name), "Dump file does not exist, when overwriting"
         os.remove(file_name)
 
-        # check RQAOA dump fails when prepend_id is True and file_name is not given
+        # check QAOA dump fails when prepend_id is True and file_name is not given
         error = False
         try:
             qaoa.dump(prepend_id=False)
@@ -1042,8 +1042,18 @@ class TestingVanillaQAOA(unittest.TestCase):
             error
         ), "Dump file does not fail when prepend_id is True and file_name is not given"
 
-        # check you can dump to a file with no arguments
-        qaoa.dump()
+        # check QAOA dump with no arguments
+        error = False
+        try:
+            qaoa.dump()
+        except ValueError:
+            error = True
+        assert (
+            error
+        ), "Dump file does not fail when no arguments are given, should be the same as dump(prepend_id=False)"
+
+        # check you can dump to a file with no arguments, just prepend_id=True
+        qaoa.dump(prepend_id=True)
         assert os.path.isfile(
             f"{project_id}--{experiment_id}--{atomic_id}.json"
         ), "Dump file does not exist, when no name is given"
@@ -1051,7 +1061,7 @@ class TestingVanillaQAOA(unittest.TestCase):
 
         # check QAOA dump deleting some keys
         exclude_keys = ["schedule", "singlet"]
-        qaoa.dump(file_name, exclude_keys=exclude_keys, indent=None)
+        qaoa.dump(file_name, exclude_keys=exclude_keys, indent=None, prepend_id=True)
         assert os.path.isfile(
             full_name
         ), "Dump file does not exist, when deleting some keys"
@@ -1062,7 +1072,7 @@ class TestingVanillaQAOA(unittest.TestCase):
         os.remove(full_name)
 
         # check QAOA dump with compression
-        qaoa.dump(file_name, compresslevel=2, indent=None)
+        qaoa.dump(file_name, compresslevel=2, indent=None, prepend_id=True)
         assert os.path.isfile(
             full_name + ".gz"
         ), "Dump file does not exist, when compressing"
@@ -1881,7 +1891,7 @@ class TestingRQAOA(unittest.TestCase):
         )
         full_name = f"{project_id}--{experiment_id}--{atomic_id}--{file_name}"
 
-        rqaoa.dump(file_name, indent=None)
+        rqaoa.dump(file_name, prepend_id=True, indent=None)
         assert os.path.isfile(full_name), "Dump file does not exist"
         with open(full_name, "r") as file:
             assert file.read() == rqaoa.dumps(
@@ -1918,8 +1928,18 @@ class TestingRQAOA(unittest.TestCase):
             error
         ), "Dump file does not fail when prepend_id is True and file_name is not given"
 
-        # check you can dump to a file with no arguments
-        rqaoa.dump()
+        # check RQAOA dump with no arguments
+        error = False
+        try:
+            rqaoa.dump()
+        except ValueError:
+            error = True
+        assert (
+            error
+        ), "Dump file does not fail when no arguments are given, should be the same as dump(prepend_id=False)"
+
+        # check you can dump to a file with no arguments, just prepend_id=True
+        rqaoa.dump(prepend_id=True)
         assert os.path.isfile(
             f"{project_id}--{experiment_id}--{atomic_id}.json"
         ), "Dump file does not exist, when no name is given"
@@ -1927,7 +1947,7 @@ class TestingRQAOA(unittest.TestCase):
 
         # check RQAOA dump deleting some keys
         exclude_keys = ["schedule", "singlet"]
-        rqaoa.dump(file_name, exclude_keys=exclude_keys, indent=None)
+        rqaoa.dump(file_name, exclude_keys=exclude_keys, indent=None, prepend_id=True)
         assert os.path.isfile(
             full_name
         ), "Dump file does not exist, when deleting some keys"
@@ -1938,7 +1958,7 @@ class TestingRQAOA(unittest.TestCase):
         os.remove(full_name)
 
         # check RQAOA dump with compression
-        rqaoa.dump(file_name, compresslevel=2, indent=None)
+        rqaoa.dump(file_name, compresslevel=2, indent=None, prepend_id=True)
         assert os.path.isfile(
             full_name + ".gz"
         ), "Dump file does not exist, when compressing"
@@ -2138,6 +2158,7 @@ class TestingRQAOA(unittest.TestCase):
                 "file_name": "test_dumping_step_by_step",
                 "compresslevel": 2,
                 "indent": None,
+                "prepend_id": True,
             },
         )
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -998,11 +998,12 @@ class TestingVanillaQAOA(unittest.TestCase):
 
         # check QAOA dump
         file_name = "test_dump_qaoa.json"
-        experiment_id, atomic_id = (
+        project_id, experiment_id, atomic_id = (
+            qaoa.header["project_id"],
             qaoa.header["experiment_id"],
             qaoa.header["atomic_id"],
         )
-        full_name = f"{experiment_id}--{atomic_id}--{file_name}"
+        full_name = f"{project_id}--{experiment_id}--{atomic_id}--{file_name}"
 
         qaoa.dump(file_name, indent=None)
         assert os.path.isfile(full_name), "Dump file does not exist"
@@ -1044,9 +1045,9 @@ class TestingVanillaQAOA(unittest.TestCase):
         # check you can dump to a file with no arguments
         qaoa.dump()
         assert os.path.isfile(
-            f"{experiment_id}--{atomic_id}.json"
+            f"{project_id}--{experiment_id}--{atomic_id}.json"
         ), "Dump file does not exist, when no name is given"
-        os.remove(f"{experiment_id}--{atomic_id}.json")
+        os.remove(f"{project_id}--{experiment_id}--{atomic_id}.json")
 
         # check QAOA dump deleting some keys
         exclude_keys = ["schedule", "singlet"]
@@ -1873,11 +1874,12 @@ class TestingRQAOA(unittest.TestCase):
 
         # check RQAOA dump
         file_name = "test_dump_rqaoa.json"
-        experiment_id, atomic_id = (
+        project_id, experiment_id, atomic_id = (
+            rqaoa.header["project_id"],
             rqaoa.header["experiment_id"],
             rqaoa.header["atomic_id"],
         )
-        full_name = f"{experiment_id}--{atomic_id}--{file_name}"
+        full_name = f"{project_id}--{experiment_id}--{atomic_id}--{file_name}"
 
         rqaoa.dump(file_name, indent=None)
         assert os.path.isfile(full_name), "Dump file does not exist"
@@ -1919,9 +1921,9 @@ class TestingRQAOA(unittest.TestCase):
         # check you can dump to a file with no arguments
         rqaoa.dump()
         assert os.path.isfile(
-            f"{experiment_id}--{atomic_id}.json"
+            f"{project_id}--{experiment_id}--{atomic_id}.json"
         ), "Dump file does not exist, when no name is given"
-        os.remove(f"{experiment_id}--{atomic_id}.json")
+        os.remove(f"{project_id}--{experiment_id}--{atomic_id}.json")
 
         # check RQAOA dump deleting some keys
         exclude_keys = ["schedule", "singlet"]
@@ -2140,13 +2142,16 @@ class TestingRQAOA(unittest.TestCase):
         )
 
         # create list of expected file names
+        project_id = "None"
         experiment_id, atomic_id = r.header["experiment_id"], r.header["atomic_id"]
         file_names = {
-            id: experiment_id + "--" + id + "--" + "test_dumping_step_by_step.json.gz"
+            id: project_id + "--" + experiment_id + "--" + id + "--" + "test_dumping_step_by_step.json.gz"
             for id in r.result["atomic_ids"].values()
         }
         file_names[atomic_id] = (
-            experiment_id
+            project_id
+            + "--"
+            + experiment_id
             + "--"
             + atomic_id
             + "--"


### PR DESCRIPTION
The dump method was giving the following name:
`{experiment_id}--{atomic_id}`

the correct one is:
`{project_id}--{experiment_id}--{atomic_id}`