### PR TITLE
added new dictionary method to Hamiltonian class, and few other updates

### DIFF
--- a/src/openqaoa-core/qaoa_components/ansatz_constructor/operators.py
+++ b/src/openqaoa-core/qaoa_components/ansatz_constructor/operators.py
@@ -560,6 +560,7 @@ class Hamiltonian:
         ----------
         classical: `bool`, optional
             If true, returns a dictionary containing only qubit indices as terms
+            else returns a dictionary containing PauliOp objects as terms.
 
         Returns
         -------
@@ -572,6 +573,8 @@ class Hamiltonian:
                 hamiltonian_dict[tuple(term.qubit_indices)] = coeff
             else:
                 hamiltonian_dict[term] = coeff
+            # add the constant term
+            hamiltonian_dict[()] = self.constant
         return hamiltonian_dict
 
     def __add__(self, other_hamiltonian):

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1256,6 +1256,60 @@ class TestingOperators(unittest.TestCase):
             str(context.exception),
         )
 
+    def test_hamiltonian_dict(self):
+        """Test if the method produces
+        the correct dictionary corresponding to the Hamiltonian.
+
+        It creates a dictionary of the form
+        {(i, j): coeff} where i, j are the indices of the qubits if
+        argument `classical` is set true in the function otherwise,
+        produces a dictionary of the form {PauliOp}: coeff}
+        """
+
+        # TEST 1
+        # Define Hamiltonian attributes
+        terms = [[0, 1], [0, 2], [1, 2]]
+        coefficients = [1, 0.5, 0.5]
+        constant = 2
+
+        # Generate Hamiltonian
+        hamiltonian = Hamiltonian.classical_hamiltonian(terms, coefficients, constant)
+
+        # Generate dictionary
+        hamiltonian_dict = hamiltonian.hamiltonian_dict()
+
+        # Correct dictionary
+        correct_dict = {(0, 1): 1, (0, 2): 0.5, (1, 2): 0.5}
+
+        # Test if dictionary was correctly computed
+        assert (
+            hamiltonian_dict == correct_dict
+        ), f"Hamiltonian dictionary did not yield correct dictionary"
+
+        # TEST 2
+        terms = [PauliOp("XX", (0, 1)), PauliOp("YY", (0, 2))]
+        coeffs = [1, 0.5]
+        constant = 0
+
+        # Generate Hamiltonian
+        hamiltonian = Hamiltonian(terms, coeffs, constant)
+
+        # Generate dictionaries
+        hamiltonian_dict_indices = hamiltonian.hamiltonian_dict(classical=True)
+        hamiltonian_dict_pauliop = hamiltonian.hamiltonian_dict(classical=False)
+
+        # Correct dictionaries
+        correct_dict_indices = {(0, 1): 1, (0, 2): 0.5}
+        correct_dict_pauliop = {PauliOp("XX", (0, 1)): 1, PauliOp("YY", (0, 2)): 0.5}
+
+        assert (
+            hamiltonian_dict_indices == correct_dict_indices
+        ), "Hamiltonian dictionary did not yield correct dictionary"
+
+        assert (
+            hamiltonian_dict_pauliop == correct_dict_pauliop
+        ), "Hamiltonian dictionary did not yield correct dictionary"
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1279,7 +1279,7 @@ class TestingOperators(unittest.TestCase):
         hamiltonian_dict = hamiltonian.hamiltonian_dict()
 
         # Correct dictionary
-        correct_dict = {(0, 1): 1, (0, 2): 0.5, (1, 2): 0.5}
+        correct_dict = {(0, 1): 1, (0, 2): 0.5, (1, 2): 0.5, (): 2}
 
         # Test if dictionary was correctly computed
         assert (
@@ -1299,8 +1299,12 @@ class TestingOperators(unittest.TestCase):
         hamiltonian_dict_pauliop = hamiltonian.hamiltonian_dict(classical=False)
 
         # Correct dictionaries
-        correct_dict_indices = {(0, 1): 1, (0, 2): 0.5}
-        correct_dict_pauliop = {PauliOp("XX", (0, 1)): 1, PauliOp("YY", (0, 2)): 0.5}
+        correct_dict_indices = {(0, 1): 1, (0, 2): 0.5, (): 0}
+        correct_dict_pauliop = {
+            PauliOp("XX", (0, 1)): 1,
+            PauliOp("YY", (0, 2)): 0.5,
+            (): 0,
+        }
 
         assert (
             hamiltonian_dict_indices == correct_dict_indices

--- a/tests/test_qpu_devices.py
+++ b/tests/test_qpu_devices.py
@@ -47,9 +47,6 @@ class TestingDeviceQiskit(unittest.TestCase):
         self.assertEqual(device_obj.provider.credentials.group, self.GROUP)
         self.assertEqual(device_obj.provider.credentials.project, self.PROJECT)
 
-        device_obj2 = DeviceQiskit(device_name="ibmq_manila", hub="ibm-q-startup")
-        device_obj2.check_connection()
-        self.assertEqual(device_obj2.provider.credentials.hub, "ibm-q-startup")
 
     @pytest.mark.api
     def test_check_connection_provider_no_backend_wrong_hub_group_project(self):


### PR DESCRIPTION
## Description

- Added new method to `Hamiltonian` object that constructs a dictionary of terms (either `PaulIOp`s or qubit indices) and coefficients of the Hamiltonian object
- added `__hash__` method to PauliOp class, and fixed the `__eq__` method.

## Checklist

[//]: <> (- [x] My code follows the style guidelines of this project)

- [x] I have performed a self-review of my code.
- [x] I have commented my code and used numpy-style docstrings
- [x] I have made corresponding updates to the documentation.
- [x] My changes generate no new warnings
- [x] I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added a new unit-test in `test_operators.py` file to test the new method
