### PR TITLE
fixed permute_counts method and fixed dicke_wavefunction docstring

### DIFF
--- a/src/openqaoa-core/utilities.py
+++ b/src/openqaoa-core/utilities.py
@@ -1594,7 +1594,7 @@ def is_valid_uuid(uuid_to_test: str) -> bool:
 
 
 def permute_counts_dictionary(
-    counts_dictionary: dict, final_qubit_layout: List[int]
+    counts_dictionary: dict, permutation_order: List[int]
 ) -> dict:
     """Permutes the order of the qubits in the counts dictionary to the
     original order if SWAP gates were used leading to modified qubit layout.
@@ -1602,10 +1602,8 @@ def permute_counts_dictionary(
     ----------
     counts_dictionary : `dict`
         The measurement outcomes obtained from the Simulator/QPU
-    original_qubit_layout: List[int]
-        The qubit layout in which the qubits were initially
-    final_qubit_layout: List[int]
-        The final qubit layout after application of SWAPs
+    permutation_order: List[int]
+        The qubit order to permute the dictionary with
 
     Returns
     -------
@@ -1614,22 +1612,18 @@ def permute_counts_dictionary(
     """
 
     # Create a mapping of original positions to final positions
-    original_qubit_layout = list(range(len(final_qubit_layout)))
+    # original order always goes from 0 -> n-1
+    original_order = list(range(len(permutation_order)))
     mapping = {
-        original_qubit_layout[i]: final_qubit_layout[i]
-        for i in range(len(original_qubit_layout))
+        original_order[i]: permutation_order[i] for i in range(len(original_order))
     }
     permuted_counts = {}
 
-    for basis, counts in counts_dictionary.items():
-
-        def permute_string(basis_state: str = basis, mapping: dict = mapping):
-            # Use the mapping to permute the string
-            permuted_string = "".join(
-                [basis_state[mapping[i]] for i in range(len(basis_state))]
-            )
-            return permuted_string
-
+    for basis_state, counts in counts_dictionary.items():
+        # Use the mapping to permute the string
+        permuted_string = "".join(
+            [basis_state[mapping[i]] for i in range(len(basis_state))]
+        )
         permuted_counts.update({permuted_string: counts})
 
     return permuted_counts
@@ -1722,7 +1716,7 @@ def dicke_wavefunction(excitations, n_qubits):
 
     Parameters
     ----------
-    excitations: str
+    excitations: int
         The number of excitations in the basis
 
     n_qubits: int

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1224,6 +1224,27 @@ class TestingUtilities(unittest.TestCase):
             generated_timestamp
         ), f"Timestamp has not been generated correctly"
 
+    def test_permute_counts_dictionary(self):
+        """
+        Tests the function that permutes the counts dictionary: permute_counts_dictionary.
+        """
+
+        # Input dictionary
+        input_dict = {"011011": 1, "000111": 2, "000000": 3}
+
+        # Permute the dictionary
+        output_dict = permute_counts_dictionary(
+            input_dict, permutation_order=[4, 5, 3, 0, 1, 2]
+        )
+
+        # Expected dictionary
+        expected_dict = {"110011": 1, "111000": 2, "000000": 3}
+
+        # Test that the dictionary has been permuted correctly
+        assert (
+            output_dict == expected_dict
+        ), f"Dictionary has not been permuted correctly"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

- Fixed the definition of `permute_counts_dictionary` function in `utilities.py`
- Fixed the docstring incorrect type-hinting in `dicke_wavefunction` in `utilities.py`

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [x] I have performed a self-review of my code.
- [x] I have commented my code and used numpy-style docstrings
- [x] I have made corresponding updates to the documentation.
- [x] My changes generate no new warnings
- [x] I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added a new unit-test to `test_utilities.py`
