### PR TITLE
Fixing Deprecation Warning for importlib

### DIFF
--- a/src/openqaoa-core/backends/plugin_finder.py
+++ b/src/openqaoa-core/backends/plugin_finder.py
@@ -2,7 +2,7 @@ from importlib.metadata import entry_points
 
 def plugin_finder_dict() -> list:
     
-    available_plugins = entry_points()['openqaoa.plugins']
+    available_plugins = entry_points().select(group='openqaoa.plugins')
     
     output_dict = dict()
     for each_plugin_entry_point in available_plugins:


### PR DESCRIPTION
## Description

- Updated dictionary selector to `select` method for `importlib` `entry_points` function.

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code and used numpy-style docstrings
- [ ] I have made corresponding updates to the documentation.
- [ ] My changes generate no new warnings
- [ ] I have added/updated tests to make sure bugfix/feature works.
- [ ] New and existing unit tests pass locally with my changes.

[//]: <> (- [ ] Any dependent changes have been merged and published in downstream modules)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

test_all.py
