### PR TITLE
Bugfix dump methods

### DIFF
--- a/.github/workflows/test_main_linux.yml
+++ b/.github/workflows/test_main_linux.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           IBMQ_TOKEN=$IBMQ_TOKEN
           source env/bin/activate
-          python -c'from qiskit import IBMQ; import os; IBMQ.save_account(os.environ.get("IBMQ_TOKEN"))'
+          python -c'from qiskit_ibm_provider import IBMProvider; import os; IBMProvider.save_account(os.environ.get("IBMQ_TOKEN"))'
       - name: Setup AWS
         env:
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }} 

--- a/src/openqaoa-core/algorithms/qaoa/qaoa_result.py
+++ b/src/openqaoa-core/algorithms/qaoa/qaoa_result.py
@@ -165,14 +165,11 @@ class QAOAResult:
         # if the backend is a statevector backend, the measurement outcomes will be the statevector,
         # meaning that it is a list of complex numbers, which is not serializable.
         # If that is the case, and complex_to_string is true the complex numbers are converted to strings.
-        if complex_to_string and issubclass(
-            self.__type_backend, QAOABaseBackendStatevector
-        ):
+        if complex_to_string:
             return_dict["intermediate"] = {}
             for key, value in self.intermediate.items():
-                if (
-                    intermediate_measurements is False and "measurement" in key
-                ):  # if intermediate_measurements is false, the intermediate measurements are not included in the dump
+                if intermediate_measurements is False and "measurement" in key:
+                    # if intermediate_measurements is false, the intermediate measurements are not included in the dump
                     return_dict["intermediate"][key] = []
                 elif "measurement" in key and (
                     isinstance(value, list) or isinstance(value, np.ndarray)
@@ -184,6 +181,11 @@ class QAOAResult:
                     ]
                 else:
                     return_dict["intermediate"][key] = value
+
+                if "cost" == key and (
+                    isinstance(value[0], np.float64) or isinstance(value[0], np.float32)
+                ):
+                    return_dict["intermediate"][key] = [float(item) for item in value]
 
             return_dict["optimized"] = {}
             for key, value in self.optimized.items():
@@ -201,6 +203,11 @@ class QAOAResult:
                     }
                 else:
                     return_dict["optimized"][key] = value
+
+                if "cost" in key and (
+                    isinstance(value, np.float64) or isinstance(value, np.float32)
+                ):
+                    return_dict["optimized"][key] = float(value)
         else:
             return_dict["intermediate"] = self.intermediate
             return_dict["optimized"] = self.optimized

--- a/src/openqaoa-core/algorithms/qaoa/qaoa_result.py
+++ b/src/openqaoa-core/algorithms/qaoa/qaoa_result.py
@@ -17,7 +17,9 @@ from ...backends.qaoa_analytical_sim import QAOABackendAnalyticalSimulator
 
 
 def most_probable_bitstring(cost_hamiltonian, measurement_outcomes):
-
+    """
+    Computing the most probable bitstring
+    """
     mea_out = list(measurement_outcomes.values())
     index_likliest_states = np.argwhere(mea_out == np.max(mea_out))
     # degeneracy = len(index_likliest_states)
@@ -54,7 +56,9 @@ class QAOAResult:
         cost_hamiltonian: Type[Hamiltonian],
         type_backend: Type[QAOABaseBackend],
     ):
-
+        """
+        init method
+        """
         self.__type_backend = type_backend
         self.method = method
         self.cost_hamiltonian = cost_hamiltonian
@@ -116,7 +120,7 @@ class QAOAResult:
         self,
         keep_cost_hamiltonian: bool = True,
         complex_to_string: bool = False,
-        intermediate_mesurements: bool = True,
+        intermediate_measurements: bool = True,
         exclude_keys: List[str] = [],
     ):
         """
@@ -132,7 +136,7 @@ class QAOAResult:
         complex_to_string: `bool`
             If True, the complex numbers are converted to strings. If False, they are kept as complex numbers.
             This is useful for the JSON serialization.
-        intermediate_mesurements: bool, optional
+        intermediate_measurements: bool, optional
             If True, intermediate measurements are included in the dump.
             If False, intermediate measurements are not included in the dump.
             Default is True.
@@ -167,8 +171,8 @@ class QAOAResult:
             return_dict["intermediate"] = {}
             for key, value in self.intermediate.items():
                 if (
-                    intermediate_mesurements == False and "measurement" in key
-                ):  # if intermediate_mesurements is false, the intermediate measurements are not included in the dump
+                    intermediate_measurements is False and "measurement" in key
+                ):  # if intermediate_measurements is false, the intermediate measurements are not included in the dump
                     return_dict["intermediate"][key] = []
                 elif "measurement" in key and (
                     isinstance(value, list) or isinstance(value, np.ndarray)
@@ -183,12 +187,18 @@ class QAOAResult:
 
             return_dict["optimized"] = {}
             for key, value in self.optimized.items():
+                # If wavefunction do complex to str
                 if "measurement" in key and (
                     isinstance(value, list) or isinstance(value, np.ndarray)
                 ):
                     return_dict["optimized"][key] = [
                         complx_to_str(item) for item in value
                     ]
+                # if dictionary, convert measurement values to integers
+                elif "measurement" in key and (isinstance(value, dict)):
+                    return_dict["optimized"][key] = {
+                        k: int(v) for k, v in value.items()
+                    }
                 else:
                     return_dict["optimized"][key] = value
         else:
@@ -197,7 +207,7 @@ class QAOAResult:
 
         # if we are using a shot adaptive optimizer, we need to add the number of shots to the result,
         # so if attribute n_shots is not empty, it is added to the dictionary
-        if getattr(self, "n_shots", None) != None:
+        if getattr(self, "n_shots", None) is not None:
             return_dict["n_shots"] = self.n_shots
 
         return (
@@ -233,7 +243,7 @@ class QAOAResult:
             setattr(result, key, value)
 
         # if there is an input cost hamiltonian, it is added to the result
-        if cost_hamiltonian != None:
+        if cost_hamiltonian is not None:
             result.cost_hamiltonian = cost_hamiltonian
 
         # if the measurement_outcomes are strings, they are converted to complex numbers
@@ -281,7 +291,7 @@ class QAOAResult:
             the actual measurement counts.
         """
 
-        if type(measurement_outcomes) == type(np.array([])):
+        if isinstance(measurement_outcomes, type(np.array([]))):
             measurement_outcomes = qaoa_probabilities(measurement_outcomes)
 
         return measurement_outcomes
@@ -335,7 +345,6 @@ class QAOAResult:
         color="tab:blue",
         ax=None,
     ):
-
         """
         Helper function to plot the probabilities corresponding to each basis states
         (with prob != 0) obtained from the optimized result
@@ -359,7 +368,7 @@ class QAOAResult:
         outcome = self.optimized["measurement_outcomes"]
 
         # converting to counts dictionary if outcome is statevector
-        if type(outcome) == type(np.array([])):
+        if isinstance(outcome, type(np.array([]))):
             outcome = self.get_counts(outcome)
             # setting norm to 1 since it might differ slightly for statevectors due to numerical preicision
             norm = np.float64(1)
@@ -407,7 +416,7 @@ class QAOAResult:
         ]
         labels.append("rest")
 
-        # represent the bar with the addition of all the remaining probabilites
+        # represent the bar with the addition of all the remaining probabilities
         rest = sum(probs[n_states_to_keep:])
 
         if ax is None:
@@ -470,7 +479,7 @@ class QAOAResult:
         if ax is None:
             ax = plt.subplots(figsize=figsize)[1]
 
-        ## creating a list of parameters to plot
+        # creating a list of parameters to plot
         # if param_to_plot is not given, plot all the parameters
         if param_to_plot is None:
             param_to_plot = list(range(len(self.n_shots[0])))
@@ -504,22 +513,23 @@ class QAOAResult:
                 color = [color]
 
         # if param_top_plot is a list and label or color are not lists, raise error
-        if (type(label) != list) or (type(color) != list and color != None):
+        if (type(label) != list) or (type(color) != list and color is not None):
             raise TypeError("`label` and `color` must be list of str")
         # if label is a list, check that all the elements are strings
-        for l in label:
-            assert type(l) == str, "`label` must be a list of strings"
+        for lab in label:
+            assert type(lab) == str, "`label` must be a list of strings"
         # if color is a list, check that all the elements are strings
-        if color != None:
+        if color is not None:
             for c in color:
                 assert type(c) == str, "`color` must be a list of strings"
 
         # if label and color are lists, check if they have the same length as param_to_plot
         if len(label) != len(param_to_plot) or (
-            color != None and len(color) != len(param_to_plot)
+            color is not None and len(color) != len(param_to_plot)
         ):
             raise ValueError(
-                f"`param_to_plot`, `label` and `color` must have the same length, `param_to_plot` is a list of {len(param_to_plot)} elements"
+                f"`param_to_plot`, `label` and `color` must have the same length, \
+                    `param_to_plot` is a list of {len(param_to_plot)} elements"
             )
 
         # linestyle must be a string or a list of strings, if it is a string, convert it to a list of strings
@@ -529,7 +539,8 @@ class QAOAResult:
             linestyle = [linestyle for _ in range(len(param_to_plot))]
         elif len(linestyle) != len(param_to_plot):
             raise ValueError(
-                f"`linestyle` must have the same length as param_to_plot (length of `param_to_plot` is {len(param_to_plot)}), or be a string"
+                f"`linestyle` must have the same length as param_to_plot \
+                    (length of `param_to_plot` is {len(param_to_plot)}), or be a string"
             )
         else:
             for ls in linestyle:

--- a/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
+++ b/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
@@ -5,10 +5,8 @@ import numpy as np
 from .qaoa_result import QAOAResult
 from ..workflow_properties import CircuitProperties
 from ..baseworkflow import Workflow, check_compiled
-from ...backends.basebackend import QAOABaseBackendStatevector
 from ...backends import QAOABackendAnalyticalSimulator
-from ...backends.cost_function import cost_function
-from ...backends.devices_core import DeviceLocal, DeviceBase
+from ...backends.devices_core import DeviceLocal
 from ...backends.qaoa_backend import get_qaoa_backend
 from ...problems import QUBO
 from ...qaoa_components import (
@@ -262,11 +260,24 @@ class QAOA(Workflow):
             optimizer_dict=self.classical_optimizer.asdict(),
         )
 
+        # Set the header properties
+        self.header["target"] = self.device.device_name
+        self.header["cloud"] = self.device.device_location
+
+        metadata = {
+            "p": self.circuit_properties.p,
+            "param_type": self.circuit_properties.param_type,
+            "init_type": self.circuit_properties.init_type,
+            "optimizer_method": self.classical_optimizer.method,
+        }
+
+        self.set_exp_tags(tags=metadata)
+
         self.compiled = True
 
         if verbose:
             print("\t \033[1m ### Summary ###\033[0m")
-            print(f"OpenQAOA has been compiled with the following properties")
+            print("OpenQAOA has been compiled with the following properties")
             print(
                 f"Solving QAOA with \033[1m {self.device.device_name} \033[0m on"
                 f"\033[1m{self.device.device_location}\033[0m"
@@ -296,7 +307,7 @@ class QAOA(Workflow):
         A method running the classical optimisation loop
         """
 
-        if self.compiled == False:
+        if self.compiled is False:
             raise ValueError("Please compile the QAOA before optimizing it!")
 
         # timestamp for the start of the optimization
@@ -310,7 +321,7 @@ class QAOA(Workflow):
         self.header["execution_time_end"] = generate_timestamp()
 
         if verbose:
-            print(f"optimization completed.")
+            print("optimization completed.")
         return
 
     def evaluate_circuit(
@@ -338,10 +349,11 @@ class QAOA(Workflow):
         """
 
         # before evaluating the circuit we check that the QAOA object has been compiled
-        if self.compiled == False:
+        if self.compiled is False:
             raise ValueError("Please compile the QAOA before optimizing it!")
 
-        ## Check the type of the input parameters and save them as a QAOAVariationalBaseParams object at the variable `params_obj`
+        # Check the type of the input parameters and save them as a
+        # QAOAVariationalBaseParams object at the variable `params_obj`
 
         # if the parameters are passed as a dictionary we copy and update the variational parameters of the QAOA object
         if isinstance(params, dict):
@@ -382,7 +394,7 @@ class QAOA(Workflow):
                 f"The input params must be a list or a dictionary. Instead, received {type(params)}"
             )
 
-        ## Evaluate the QAOA circuit and return the results
+        # Evaluate the QAOA circuit and return the results
         output_dict = {
             "cost": None,
             "uncertainty": None,
@@ -409,7 +421,7 @@ class QAOA(Workflow):
         return output_dict
 
     def _serializable_dict(
-        self, complex_to_string: bool = False, intermediate_mesurements: bool = True
+        self, complex_to_string: bool = False, intermediate_measurements: bool = True
     ):
         """
         Returns all values and attributes of the object that we want to return in
@@ -426,7 +438,7 @@ class QAOA(Workflow):
         serializable_dict: dict
             A dictionary containing all the values and attributes of the object
             that we want to return in `asdict` and `dump(s)` methods.
-        intermediate_mesurements: bool
+        intermediate_measurements: bool
             If True, intermediate measurements are included in the dump.
             If False, intermediate measurements are not included in the dump.
             Default is True.
@@ -435,7 +447,7 @@ class QAOA(Workflow):
         # we call the _serializable_dict method of the parent class,
         # specifying the keys to delete from the results dictionary
         serializable_dict = super()._serializable_dict(
-            complex_to_string, intermediate_mesurements
+            complex_to_string, intermediate_measurements
         )
 
         # we add the keys of the QAOA object that we want to return

--- a/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
+++ b/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
@@ -321,7 +321,7 @@ class QAOA(Workflow):
         self.header["execution_time_end"] = generate_timestamp()
 
         if verbose:
-            print("optimization completed.")
+            print("Optimization completed.")
         return
 
     def evaluate_circuit(

--- a/src/openqaoa-core/algorithms/rqaoa/rqaoa_result.py
+++ b/src/openqaoa-core/algorithms/rqaoa/rqaoa_result.py
@@ -18,7 +18,7 @@ class RQAOAResult(dict):
         self,
         keep_cost_hamiltonian: bool = True,
         complex_to_string: bool = False,
-        intermediate_mesurements: bool = True,
+        intermediate_measurements: bool = True,
         exclude_keys: List[str] = [],
     ):
         """
@@ -32,7 +32,7 @@ class RQAOAResult(dict):
         complex_to_string : bool, optional
             If True, the complex numbers are converted to strings, by default False.
             This is useful for JSON serialization.
-        intermediate_mesurements: bool, optional
+        intermediate_measurements: bool, optional
             If True, intermediate measurements are included in the dump. If False,
             intermediate measurements are not included in the dump.
             Default is True.
@@ -55,7 +55,7 @@ class RQAOAResult(dict):
                     "qaoa_results": step["qaoa_results"].asdict(
                         keep_cost_hamiltonian,
                         complex_to_string,
-                        intermediate_mesurements,
+                        intermediate_measurements,
                     ),
                     "exp_vals_z": step["exp_vals_z"].tolist(),
                     "corr_matrix": step["corr_matrix"].tolist(),

--- a/src/openqaoa-core/algorithms/rqaoa/rqaoa_utils.py
+++ b/src/openqaoa-core/algorithms/rqaoa/rqaoa_utils.py
@@ -65,7 +65,7 @@ def max_terms(exp_vals_z: np.ndarray, corr_matrix: np.ndarray, n_elim: int):
 
     # Flag if we have have not been able to extract any relation for the terms
     if max_terms_and_stats == {}:
-        print(f"All expectation values are 0: Breaking degeneracy by fixing a qubit\n")
+        print("All expectation values are 0: Breaking degeneracy by fixing a qubit\n")
         max_terms_and_stats = {(0,): -1.0}
 
     return max_terms_and_stats
@@ -132,7 +132,7 @@ def ada_max_terms(exp_vals_z: np.ndarray, corr_matrix: np.ndarray, n_max: int):
 
     # Flag if we have have not been able to extract any relation for the terms
     if max_terms_and_stats == {}:
-        print(f"All expectation values are 0: Breaking degeneracy by fixing a qubit\n")
+        print("All expectation values are 0: Breaking degeneracy by fixing a qubit\n")
         max_terms_and_stats = {(0,): -1.0}
 
     # Correlation average magnitude
@@ -395,7 +395,7 @@ def redefine_problem(problem: QUBO, spin_map: dict):
     # get a set of all the spins to be eliminated
     eliminated_spins = set()
     for spin in spin_map.keys():
-        if spin != spin_map[spin][1] or spin_map[spin][1] == None:
+        if spin != spin_map[spin][1] or spin_map[spin][1] is None:
             eliminated_spins.add(spin)
 
     # Scan all terms and weights
@@ -605,7 +605,8 @@ def final_solution(
 
 def solution_for_vanishing_instances(hamiltonian: Hamiltonian, spin_map: dict):
     """
-    Constructs the final solution of the smallest non vanishing problem by fixing the vanishing spins arbitrarily to 1 while obeying the correlations identified by the last run of QAOA before the problem vanished.
+    Constructs the final solution of the smallest non vanishing problem by fixing the vanishing spins arbitrarily to 1
+    while obeying the correlations identified by the last run of QAOA before the problem vanished.
     Computing the classical energy of the generated string.
 
     Parameters
@@ -621,12 +622,14 @@ def solution_for_vanishing_instances(hamiltonian: Hamiltonian, spin_map: dict):
     cl_energy: `float`
         The energy of the solution wrt the cost Hamiltonian.
     cl_ground_state: `list`
-        The (single) classical solution to the problem reconstructed accordingly to the last spin map. Represented as a binary string and then cast to a list to match the output of the `ground_state_hamiltonian` function which is used usually.
+        The (single) classical solution to the problem reconstructed accordingly to the last spin map.
+        Represented as a binary string and then cast to a list to match the output of the
+        `ground_state_hamiltonian` function which is used usually.
     """
     cl_ground_state = ""
 
     for spin in spin_map.keys():
-        if spin_map[spin][1] == None:
+        if spin_map[spin][1] is None:
             cl_ground_state += "1"
         else:
             # fix according to correlation factor

--- a/src/openqaoa-core/algorithms/rqaoa/rqaoa_workflow.py
+++ b/src/openqaoa-core/algorithms/rqaoa/rqaoa_workflow.py
@@ -494,7 +494,7 @@ class RQAOA(Workflow):
         # dump the object if dump is true
         if dump:
             self.dump(
-                **{**dump_options, **{"options": {"intermediate_mesurements": False}}}
+                **{**dump_options, **{"options": {"intermediate_measurements": False}}}
             )
 
         if verbose:
@@ -548,7 +548,7 @@ class RQAOA(Workflow):
         return (n_qubits - n_cutoff) if (n_qubits - n_cutoff) < n else n
 
     def _serializable_dict(
-        self, complex_to_string: bool = False, intermediate_mesurements: bool = True
+        self, complex_to_string: bool = False, intermediate_measurements: bool = True
     ):
         """
         Returns all values and attributes of the object that we want to
@@ -565,7 +565,7 @@ class RQAOA(Workflow):
         serializable_dict: dict
             Dictionary containing all the values and attributes of the object
             that we want to return in `asdict` and `dump(s)` methods.
-        intermediate_mesurements: bool
+        intermediate_measurements: bool
             If True, intermediate measurements are included in the dump. If False,
             intermediate measurements are not included in the dump.
             Default is True.
@@ -573,7 +573,7 @@ class RQAOA(Workflow):
         # we call the _serializable_dict method of the parent class,
         # specifying the keys to delete from the results dictionary
         serializable_dict = super()._serializable_dict(
-            complex_to_string, intermediate_mesurements
+            complex_to_string, intermediate_measurements
         )
 
         # we add the keys of the RQAOA object that we want to return

--- a/src/openqaoa-core/algorithms/rqaoa/rqaoa_workflow.py
+++ b/src/openqaoa-core/algorithms/rqaoa/rqaoa_workflow.py
@@ -28,7 +28,7 @@ class RQAOA(Workflow):
 
     .. note::
         The attributes of the RQAOA class should be initialized using the set methods of QAOA.
-        For example, to set the qaoa circuit's depth to 10 you should run `set_circuit_properties(p=10)`
+        For example, to set the qaoa circuit's depth to 10 you should run `fecircuit_properties(p=10)`
 
     Attributes
     ----------

--- a/src/openqaoa-core/algorithms/rqaoa/rqaoa_workflow.py
+++ b/src/openqaoa-core/algorithms/rqaoa/rqaoa_workflow.py
@@ -28,7 +28,7 @@ class RQAOA(Workflow):
 
     .. note::
         The attributes of the RQAOA class should be initialized using the set methods of QAOA.
-        For example, to set the qaoa circuit's depth to 10 you should run `fecircuit_properties(p=10)`
+        For example, to set the qaoa circuit's depth to 10 you should run `set_circuit_properties(p=10)`
 
     Attributes
     ----------

--- a/src/openqaoa-core/algorithms/rqaoa/rqaoa_workflow_properties.py
+++ b/src/openqaoa-core/algorithms/rqaoa/rqaoa_workflow_properties.py
@@ -53,10 +53,11 @@ class RqaoaParameters(WorkflowProperties):
         n_max: `int`
             Maximum number of eliminations allowed at each step when using the adaptive method. Defaults to 1.
         steps: `Union[list,int]`
-            Elimination schedule for the RQAOA algorithm. If an integer is passed, it sets the number of spins eliminated
-            at each step. If a list is passed, the algorithm will follow the list to select how many spins to eliminate
-            at each step. Note that the list needs enough elements to specify eliminations from the initial number of qubits
-            up to the cutoff value. If the list contains more, the algorithm will follow instructions until the cutoff value
+            Elimination schedule for the RQAOA algorithm. If an integer is passed, it sets the number of spins
+            eliminated at each step. If a list is passed, the algorithm will follow the list to select
+            how many spins to eliminate at each step. Note that the list needs enough elements to specify
+            eliminations from the initial number of qubits up to the cutoff value. If the list contains more,
+            the algorithm will follow instructions until the cutoff value
             is reached. Defaults to 1.
         n_cutoff: `int`
             Cutoff value at which the RQAOA algorithm obtains the solution classically. Defaults to 5.
@@ -74,7 +75,7 @@ class RqaoaParameters(WorkflowProperties):
         self.counter = counter
 
         # check if the rqaoa type is correct
-        if not self.rqaoa_type in ALLOWED_RQAOA_TYPES:
+        if self.rqaoa_type not in ALLOWED_RQAOA_TYPES:
             self.compiled = False
             raise Exception(
                 f'rqaoa_type {self.rqaoa_type} is not supported. Please select "adaptive" or "custom".'
@@ -84,16 +85,17 @@ class RqaoaParameters(WorkflowProperties):
         if self.rqaoa_type == "adaptive":
             if self.steps != 1:
                 raise ValueError(
-                    f"When using the adaptive method, the `steps` parameter is not required.  \
+                    "When using the adaptive method, the `steps` parameter is not required.  \
                     The parameter that specifies the maximum number of eliminations per step is `n_max`."
                 )
             if self.counter != 0:
                 raise ValueError(
-                    f"When using the adaptive method, the `counter` parameter is not required."
+                    "When using the adaptive method, the `counter` parameter is not required."
                 )
         else:
             if self.n_max != 1:
                 raise ValueError(
-                    f"When using the custom method, the `n_max` parameter is not required.  \
-                    The parameter that specifies the number of eliminations is `steps`, which can be a string or a list."
+                    "When using the custom method, the `n_max` parameter is not required.  \
+                    The parameter that specifies the number of eliminations is `steps`,\
+                          which can be a string or a list."
                 )

--- a/tests/jobs_test_input/input_data/openqaoa_params.json
+++ b/tests/jobs_test_input/input_data/openqaoa_params.json
@@ -1,9 +1,9 @@
 {
   "header": {
-    "atomic_id": "210a6aaa-932d-45a6-b260-f3fdd085c547",
-    "experiment_id": "74779bb1-867c-4131-89d2-ac9238422cd9",
+    "atomic_id": "4d2598da-167e-4c2b-8134-852f9bfcf167",
+    "experiment_id": "8f62d958-2d10-4253-a829-77c634826e12",
     "project_id": null,
-    "algorithm": "rqaoa",
+    "algorithm": "qaoa",
     "description": null,
     "run_by": null,
     "provider": null,
@@ -19,10 +19,7 @@
       "optimizer_method": "cobyla",
       "param_type": "standard",
       "init_type": "ramp",
-      "p": 1,
-      "rqaoa_type": "custom",
-      "rqaoa_n_max": 1,
-      "rqaoa_n_cutoff": 3
+      "p": 1
     }
   },
   "data": {
@@ -212,8 +209,8 @@
     },
     "input_parameters": {
       "device": {
-        "device_location": "local",
-        "device_name": "vectorized"
+        "device_location": "aws",
+        "device_name": "arn:aws:braket:::device/quantum-simulator/amazon/sv1"
       },
       "backend_properties": {
         "init_hadamard": true,
@@ -232,7 +229,7 @@
       "classical_optimizer": {
         "optimize": true,
         "method": "cobyla",
-        "maxiter": 3,
+        "maxiter": "5",
         "maxfev": null,
         "jac": null,
         "hess": null,
@@ -263,22 +260,6 @@
         "mixer_qubit_connectivity": null,
         "mixer_coeffs": null,
         "seed": null
-      },
-      "rqaoa_parameters": {
-        "rqaoa_type": "custom",
-        "n_max": 1,
-        "steps": [
-          2,
-          2,
-          2,
-          2,
-          2,
-          2,
-          2
-        ],
-        "n_cutoff": 3,
-        "original_hamiltonian": null,
-        "counter": 0
       }
     },
     "result": null

--- a/tests/jobs_test_input/input_data/openqaoa_params.json
+++ b/tests/jobs_test_input/input_data/openqaoa_params.json
@@ -1,29 +1,34 @@
 {
   "header": {
-    "atomic_id": "4d2598da-167e-4c2b-8134-852f9bfcf167",
-    "experiment_id": "8f62d958-2d10-4253-a829-77c634826e12",
+    "atomic_id": "386997de-0e90-4e1c-8236-cd722801615f",
+    "experiment_id": "ce2f83d7-4000-4507-9e98-96e3f9afd55e",
     "project_id": null,
-    "algorithm": "qaoa",
+    "algorithm": "rqaoa",
     "description": null,
     "run_by": null,
     "provider": null,
     "target": null,
     "cloud": null,
     "client": null,
-    "qubit_number": 10,
     "execution_time_start": null,
     "execution_time_end": null,
     "metadata": {
+      "qubit_number": 10,
       "problem_type": "minimum_vertex_cover",
       "n_shots": 100,
       "optimizer_method": "cobyla",
       "param_type": "standard",
       "init_type": "ramp",
-      "p": 1
+      "p": 1,
+      "rqaoa_type": "custom",
+      "rqaoa_n_max": 1,
+      "rqaoa_n_cutoff": 6
     }
   },
   "data": {
-    "exp_tags": {},
+    "exp_tags": {
+      "qubit_number": 10
+    },
     "input_problem": {
       "terms": [
         [
@@ -229,7 +234,7 @@
       "classical_optimizer": {
         "optimize": true,
         "method": "cobyla",
-        "maxiter": "5",
+        "maxiter": 3,
         "maxfev": null,
         "jac": null,
         "hess": null,
@@ -260,6 +265,19 @@
         "mixer_qubit_connectivity": null,
         "mixer_coeffs": null,
         "seed": null
+      },
+      "rqaoa_parameters": {
+        "rqaoa_type": "custom",
+        "n_max": 1,
+        "steps": [
+          1,
+          1,
+          1,
+          1
+        ],
+        "n_cutoff": 6,
+        "original_hamiltonian": null,
+        "counter": 0
       }
     },
     "result": null

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -97,7 +97,7 @@ class TestingBackendQPUs(unittest.TestCase):
     credentials.
     """
 
-    @pytest.mark.api
+    @pytest.mark.qpu
     def setUp(self):
         self.HUB = "ibm-q"
         self.GROUP = "open"

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -62,7 +62,8 @@ class TestingBackendLocal(unittest.TestCase):
                     ).values()
                 )
                 == 58
-            ), "`n_shots` is not being respected for the local simulator `{}` when calling backend.get_counts(n_shots=58).".format(
+            ), "`n_shots` is not being respected for the local simulator `{}` when \
+                calling backend.get_counts(n_shots=58).".format(
                 device_name
             )
             if isinstance(backend, QAOABaseBackendShotBased):
@@ -70,7 +71,8 @@ class TestingBackendLocal(unittest.TestCase):
                     backend.expectation(params=variational_params_std, n_shots=58)
                 except Exception:
                     raise Exception(
-                        "backend.expectation does not admit `n_shots` as an argument for the local simulator `{}`.".format(
+                        "backend.expectation does not admit `n_shots` as an argument \
+                            for the local simulator `{}`.".format(
                             device_name
                         )
                     )
@@ -80,7 +82,8 @@ class TestingBackendLocal(unittest.TestCase):
                     )
                 except Exception:
                     raise Exception(
-                        "backend.expectation_w_uncertainty does not admit `n_shots` as an argument for the local simulator `{}`.".format(
+                        "backend.expectation_w_uncertainty does not admit `n_shots` \
+                            as an argument for the local simulator `{}`.".format(
                             device_name
                         )
                     )
@@ -94,7 +97,7 @@ class TestingBackendQPUs(unittest.TestCase):
     credentials.
     """
 
-    @pytest.mark.qpu
+    @pytest.mark.api
     def setUp(self):
         self.HUB = "ibm-q"
         self.GROUP = "open"
@@ -186,7 +189,8 @@ class TestingBackendQPUs(unittest.TestCase):
                     init_hadamard=True,
                 )
 
-                # Check that the .get_counts, .expectation and .expectation_w_variance methods admit n_shots as an argument
+                # Check that the .get_counts, .expectation and .expectation_w_variance methods
+                # admit n_shots as an argument
                 assert (
                     sum(
                         backend.get_counts(
@@ -194,8 +198,8 @@ class TestingBackendQPUs(unittest.TestCase):
                         ).values()
                     )
                     == 58
-                ), "`n_shots` \
-                        is not being respected when calling .get_counts(n_shots=58).".format(
+                ), "`n_shots` is not being respected \
+                    when calling .get_counts(n_shots=58) for QPU `{}`.".format(
                     QPU_name
                 )
                 backend.expectation(params=variational_params_std, n_shots=58)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,6 +1,5 @@
 import unittest
 import json
-import os
 import pytest
 import subprocess
 
@@ -38,12 +37,13 @@ class TestingBackendLocal(unittest.TestCase):
 
     def test_get_counts_and_expectation_n_shots(self):
         """
-        Check that the .get_counts admit n_shots as an argument, and works properly for the backend of all local devices.
-        Also check that .expectation and .expecation_w_uncertainty methods admit n_shots as an argument for the QAOABaseBackendShotBased backends.
+        Check that the .get_counts admit n_shots as an argument, and works properly for
+          the backend of all local devices.
+        Also check that .expectation and .expecation_w_uncertainty methods admit n_shots
+         as an argument for the QAOABaseBackendShotBased backends.
         """
 
         for device_name in DEVICE_NAME_TO_OBJECT_MAPPER.keys():
-
             # Analytical device doesn't have any of those so we are skipping it in the tests.
             if device_name in ["analytical_simulator"]:
                 continue
@@ -96,7 +96,6 @@ class TestingBackendQPUs(unittest.TestCase):
 
     @pytest.mark.qpu
     def setUp(self):
-
         self.HUB = "ibm-q"
         self.GROUP = "open"
         self.PROJECT = "main"
@@ -123,9 +122,11 @@ class TestingBackendQPUs(unittest.TestCase):
     @pytest.mark.qpu
     def test_get_counts_and_expectation_n_shots(self):
         """
-        TODO: test needs to be updated as DEVICE_ACCESS_OBJECT_MAPPER is now dynamically filled based on whether a module exists.
-        
-        Check that the .get_counts, .expectation and .expecation_w_uncertainty methods admit n_shots as an argument for the backends of all QPUs.
+        TODO: test needs to be updated as DEVICE_ACCESS_OBJECT_MAPPER is now dynamically filled
+        based on whether a module exists.
+
+        Check that the .get_counts, .expectation and .expecation_w_uncertainty methods
+        admit n_shots as an argument for the backends of all QPUs.
         """
 
         list_device_attributes = [
@@ -134,7 +135,7 @@ class TestingBackendQPUs(unittest.TestCase):
                 "device_name": "rigetti.sim.qvm",
                 "resource_id": self.RESOURCE_ID,
                 "az_location": self.AZ_LOCATION,
-            }, 
+            },
             {
                 "QPU": "AWS",
                 "device_name": "arn:aws:braket:::device/quantum-simulator/amazon/sv1",
@@ -157,12 +158,12 @@ class TestingBackendQPUs(unittest.TestCase):
 
         assert len(list_device_attributes) == len(
             DEVICE_ACCESS_OBJECT_MAPPER
-        ), "The number of QPUs in the list of tests is not the same as the number of QPUs in the DEVICE_ACCESS_OBJECT_MAPPER. The list should be updated."
+        ), "The number of QPUs in the list of tests is not the same as the number of QPUs in \
+             the DEVICE_ACCESS_OBJECT_MAPPER. The list should be updated."
         print(DEVICE_ACCESS_OBJECT_MAPPER.items(), list_device_attributes)
         for (device, backend), device_attributes in zip(
             DEVICE_ACCESS_OBJECT_MAPPER.items(), list_device_attributes
         ):
-
             qaoa_descriptor, variational_params_std = get_params()
 
             QPU_name = device_attributes.pop("QPU")
@@ -193,7 +194,8 @@ class TestingBackendQPUs(unittest.TestCase):
                         ).values()
                     )
                     == 58
-                ), "`n_shots` is not being respected when calling .get_counts(n_shots=58).".format(
+                ), "`n_shots` \
+                        is not being respected when calling .get_counts(n_shots=58).".format(
                     QPU_name
                 )
                 backend.expectation(params=variational_params_std, n_shots=58)
@@ -202,7 +204,6 @@ class TestingBackendQPUs(unittest.TestCase):
                 )
 
             except Exception as e:
-
                 raise e from type(e)(f"Error raised for `{QPU_name}`: " + str(e))
 
             print("Test passed for {} backend.".format(QPU_name))

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,6 +1,8 @@
 import unittest
 import numpy as np
 import matplotlib.pyplot as plt
+import pytest
+import sys
 
 from openqaoa import QAOA, create_device, QAOABenchmark
 from openqaoa.problems import QUBO
@@ -89,6 +91,10 @@ class TestingBenchmark(unittest.TestCase):
             benchmark.reference.backend, type(qaoa_vectorized.backend)
         ), "The qaoa reference should have a vectorized backend."
 
+    @pytest.mark.skipif(
+        sys.platform == "darwin" or sys.platform.startswith("win"),
+        reason="Test does not run on Mac and Windows currently",
+    )
     def __compare_values_benchmark(
         self,
         qaoa,
@@ -196,6 +202,10 @@ class TestingBenchmark(unittest.TestCase):
                 n_points_axis, ranges, run_reference
             )
 
+    @pytest.mark.skipif(
+        sys.platform == "darwin" or sys.platform.startswith("win"),
+        reason="Test does not run on Mac and Windows currently",
+    )
     def test_values_1D(self):
         "Test the values of the benchmark for 1D ranges."
 
@@ -234,6 +244,10 @@ class TestingBenchmark(unittest.TestCase):
             ],
         )
 
+    @pytest.mark.skipif(
+        sys.platform == "darwin" or sys.platform.startswith("win"),
+        reason="Test does not run on Mac and Windows currently",
+    )
     def test_values_2D(self):
         "Test the values of the benchmark for 2D ranges."
 
@@ -259,6 +273,10 @@ class TestingBenchmark(unittest.TestCase):
             run_reference=True,
         )
 
+    @pytest.mark.skipif(
+        sys.platform == "darwin" or sys.platform.startswith("win"),
+        reason="Test does not run on Mac and Windows currently",
+    )
     def test_values_3D(self):
         "Test the values of the benchmark for 3D ranges."
 
@@ -284,6 +302,10 @@ class TestingBenchmark(unittest.TestCase):
             run_reference=True,
         )
 
+    @pytest.mark.skipif(
+        sys.platform == "darwin" or sys.platform.startswith("win"),
+        reason="Test does not run on Mac and Windows currently",
+    )
     def test_difference(self):
         "Test the property difference and difference_mean."
 
@@ -353,6 +375,10 @@ class TestingBenchmark(unittest.TestCase):
             error
         ), "An error should be raised if the difference is called before running the benchmark."
 
+    @pytest.mark.skipif(
+        sys.platform == "darwin" or sys.platform.startswith("win"),
+        reason="Test does not run on Mac and Windows currently",
+    )
     def test_input_checks(self):
         "Test the input assertions of the run method."
 
@@ -437,6 +463,10 @@ class TestingBenchmark(unittest.TestCase):
             benchmark.run, n_points_axis=4, ranges=[(1, 2), (1, 3)], verbose="d"
         ), "An error should be raised when verbose is not a boolean."
 
+    @pytest.mark.skipif(
+        sys.platform == "darwin" or sys.platform.startswith("win"),
+        reason="Test does not run on Mac and Windows currently",
+    )
     def test_plot(self):
         "Test the plot method."
 
@@ -477,6 +507,10 @@ class TestingBenchmark(unittest.TestCase):
         benchmark.run(n_points_axis=4, ranges=[(0, np.pi), (-5, 9), (0, 1), (1,)])
         benchmark.plot()
 
+    @pytest.mark.skipif(
+        sys.platform == "darwin" or sys.platform.startswith("win"),
+        reason="Test does not run on Mac and Windows currently",
+    )
     def test_plot_inputs(self):
         "Test the plot method with different inputs."
 
@@ -529,6 +563,10 @@ class TestingBenchmark(unittest.TestCase):
         plt.show()
         plt.close(fig)
 
+    @pytest.mark.skipif(
+        sys.platform == "darwin" or sys.platform.startswith("win"),
+        reason="Test does not run on Mac and Windows currently",
+    )
     def test_plot_input_checks(self):
         "Test the plot method assertion inputs."
 
@@ -616,8 +654,11 @@ class TestingBenchmark(unittest.TestCase):
             benchmark.plot, main=False, reference=False, difference=True
         ), "An error should be raised when no values are available"
 
+    @pytest.mark.skipif(
+        sys.platform == "darwin" or sys.platform.startswith("win"),
+        reason="Test does not run on Mac and Windows currently",
+    )
     def test_run_w_plots(self):
-
         qaoa = QAOA()
         qaoa.compile(QUBO.random_instance(5))
         benchmark = QAOABenchmark(qaoa)

--- a/tests/test_circuit_routing.py
+++ b/tests/test_circuit_routing.py
@@ -594,7 +594,6 @@ class ExpectedRouting:
 
 
 class TestingQubitRouting(unittest.TestCase):
-    @pytest.mark.qpu
     def setUp(self):
         """
         Test edge cases

--- a/tests/test_circuit_routing.py
+++ b/tests/test_circuit_routing.py
@@ -1,10 +1,10 @@
 # unit testing for circuit routing functionality in OQ
 import unittest
 import numpy as np
-from typing import List, Callable, Optional
+from typing import List, Optional
 import pytest
 
-from openqaoa import QAOA
+from openqaoa import QAOA, create_device, QUBO
 from openqaoa.qaoa_components import (
     create_qaoa_variational_params,
     QAOADescriptor,
@@ -12,8 +12,7 @@ from openqaoa.qaoa_components import (
     Hamiltonian,
 )
 from openqaoa.utilities import X_mixer_hamiltonian
-from openqaoa.backends import QAOAvectorizedBackendSimulator, create_device
-from openqaoa.problems import NumberPartition, QUBO, Knapsack, MaximumCut, ShortestPath
+from openqaoa.problems import NumberPartition, Knapsack, MaximumCut, ShortestPath
 from openqaoa_pyquil.backends import DevicePyquil, QAOAPyQuilQPUBackend
 from openqaoa.backends.devices_core import DeviceBase
 from openqaoa.qaoa_components.ansatz_constructor.gatemap import SWAPGateMap
@@ -35,7 +34,6 @@ class TestingQAOAPyquilQVM_QR(unittest.TestCase):
         """
 
         def routing_function_test1(device, problem_to_solve):
-
             # tuples ordered from 0,n, both SWAP and ising gates
             gate_list_indices = [[0, 1]]
 
@@ -117,7 +115,6 @@ class TestingQAOAPyquilQVM_QR(unittest.TestCase):
         device_pyquil.quantum_computer.qam.random_seed = seed
 
         for i in range(len(p_lst)):
-
             p = p_lst[i]
             args = args_lst[i]
             cost_hamil = cost_hamil_lst[i]
@@ -166,14 +163,13 @@ class TestingQAOAPyquilQVM_QR(unittest.TestCase):
 
     def test_cancelled_swap(self):
         """
-        Tests that QAOADescriptor with a trivial `routing_function` input (with two swaps that cancel each other) returns identical
-        results as QAOADescriptor with no `routing_function` input, by comparing output of seeded QVM run.
-        Different values of p, arguments, and cost hamiltonian coefficients are tested.
-
+        Tests that QAOADescriptor with a trivial `routing_function` input (with two swaps that cancel each other)
+        returns identical results as QAOADescriptor with no `routing_function` input,
+        by comparing output of seeded QVM run. Different values of p, arguments,
+        and cost hamiltonian coefficients are tested.
         """
 
         def routing_function_test1(device, problem_to_solve):
-
             # tuples ordered from 0,n, both SWAP and ising gates
             gate_list_indices = [[0, 1], [0, 1], [0, 1]]
 
@@ -255,7 +251,6 @@ class TestingQAOAPyquilQVM_QR(unittest.TestCase):
         device_pyquil.quantum_computer.qam.random_seed = seed
 
         for i in range(len(p_lst)):
-
             p = p_lst[i]
             args = args_lst[i]
             cost_hamil = cost_hamil_lst[i]
@@ -314,7 +309,6 @@ class TestingQAOAPyquilQVM_QR(unittest.TestCase):
         """
 
         def routing_function_test1(device, problem_to_solve):
-
             # tuples ordered from 0,n, both SWAP and ising gates
             gate_list_indices = [[0, 1], [0, 1]]
 
@@ -396,7 +390,6 @@ class TestingQAOAPyquilQVM_QR(unittest.TestCase):
         device_pyquil.quantum_computer.qam.random_seed = seed
 
         for i in range(len(p_lst)):
-
             p = p_lst[i]
             args = args_lst[i]
             cost_hamil = cost_hamil_lst[i]
@@ -454,7 +447,6 @@ class TestingQAOAPyquilQVM_QR(unittest.TestCase):
         """
 
         def routing_function_test1(device, problem_to_solve):
-
             # tuples ordered from 0,n, both SWAP and ising gates
             gate_list_indices = [[0, 1], [1, 0], [0, 1]]
 
@@ -500,7 +492,6 @@ class TestingQAOAPyquilQVM_QR(unittest.TestCase):
         seed = 1
 
         for i in range(len(p_lst)):
-
             p = p_lst[i]
             args = args_lst[i]
             cost_hamil = cost_hamil_lst[i]
@@ -605,7 +596,9 @@ class ExpectedRouting:
 class TestingQubitRouting(unittest.TestCase):
     @pytest.mark.qpu
     def setUp(self):
-
+        """
+        Test edge cases
+        """
         # case qubits device > qubits problem (IBM NAIROBI)
         self.IBM_NAIROBI_KNAPSACK = ExpectedRouting(
             qubo=Knapsack.random_instance(n_items=3, seed=20).qubo,
@@ -882,7 +875,7 @@ class TestingQubitRouting(unittest.TestCase):
         )
 
         # case qubits device == qubits problem (RIGETTI)
-        self.RIGETTI_MACUT = ExpectedRouting(
+        self.RIGETTI_MAXCUT = ExpectedRouting(
             qubo=MaximumCut.random_instance(
                 n_nodes=9, edge_probability=0.9, seed=20
             ).qubo,
@@ -1132,7 +1125,6 @@ class TestingQubitRouting(unittest.TestCase):
 
     @pytest.mark.qpu
     def test_qubit_routing(self):
-
         for i, case in enumerate(self.list_of_cases):
             print("Test case {} out of {}:".format(i + 1, len(self.list_of_cases)))
             self.__compare_results(case, p=i % 4 + 1)

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -6,18 +6,18 @@ import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
 import pytest
 
-import sys, os
+import sys
+import os
 
 myPath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, myPath + "/../")
 
 
 def notebook_test_function(name):
-
     with open(name, encoding="utf-8") as f:
         nb = nbformat.read(f, as_version=4)
 
-    ep = ExecutePreprocessor(timeout=600, kernel_name="env")
+    ep = ExecutePreprocessor(timeout=600, kernel_name="fix_oq_bugs")
 
     ep.preprocess(nb)
 
@@ -88,8 +88,7 @@ def test_X_dumping_data():
     notebook_test_function("./examples/X_dumping_data.ipynb")
 
 
-### Community Tutorials
-
+# Community Tutorials
 # @pytest.mark.notebook
 def test_tutorial_quantum_approximate_optimization_algorithm():
     notebook_test_function(

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -17,7 +17,7 @@ def notebook_test_function(name):
     with open(name, encoding="utf-8") as f:
         nb = nbformat.read(f, as_version=4)
 
-    ep = ExecutePreprocessor(timeout=600, kernel_name="fix_oq_bugs")
+    ep = ExecutePreprocessor(timeout=600, kernel_name="env")
 
     ep.preprocess(nb)
 

--- a/tests/test_qpu_braket.py
+++ b/tests/test_qpu_braket.py
@@ -87,7 +87,6 @@ class TestingQAOABraketQPUBackend(unittest.TestCase):
 
         self.assertEqual(main_circuit, qpu_circuit)
 
-
     @pytest.mark.braket_api
     def test_circuit_angle_assignment_qpu_backend_w_hadamard(self):
         """
@@ -150,7 +149,6 @@ class TestingQAOABraketQPUBackend(unittest.TestCase):
 
         self.assertEqual(main_circuit, qpu_circuit)
 
-
     @pytest.mark.braket_api
     def test_prepend_circuit(self):
         """
@@ -209,7 +207,6 @@ class TestingQAOABraketQPUBackend(unittest.TestCase):
         main_circuit.probability()
 
         self.assertEqual(main_circuit, qpu_circuit)
-
 
     @pytest.mark.braket_api
     def test_append_circuit(self):
@@ -271,10 +268,8 @@ class TestingQAOABraketQPUBackend(unittest.TestCase):
 
         self.assertEqual(main_circuit, qpu_circuit)
 
-
     @pytest.mark.braket_api
     def test_prepend_exception(self):
-
         """
         Test that the error catching for a prepend ciruit larger than the problem
         circuit is invalid
@@ -301,12 +296,15 @@ class TestingQAOABraketQPUBackend(unittest.TestCase):
         )
         mixer_hamil = X_mixer_hamiltonian(n_qubits=nqubits)
         qaoa_descriptor = QAOADescriptor(cost_hamil, mixer_hamil, p=p)
-        variate_params = QAOAVariationalStandardParams(qaoa_descriptor, betas, gammas)
+
+        # Try to create the variate params
+        _ = QAOAVariationalStandardParams(qaoa_descriptor, betas, gammas)
 
         aws_device = DeviceAWS("arn:aws:braket:::device/quantum-simulator/amazon/sv1")
 
         try:
-            aws_backend = QAOAAWSQPUBackend(
+            # Try to create the AWS backend
+            _ = QAOAAWSQPUBackend(
                 qaoa_descriptor, aws_device, shots, prepend_circuit, None, True, 1.0
             )
         except Exception as e:
@@ -316,7 +314,6 @@ class TestingQAOABraketQPUBackend(unittest.TestCase):
 
     @pytest.mark.braket_api
     def test_exceptions_in_init(self):
-
         """
         Testing the Exceptions in the init function of the QAOAAWSQPUBackend
         """
@@ -335,7 +332,9 @@ class TestingQAOABraketQPUBackend(unittest.TestCase):
         )
         mixer_hamil = X_mixer_hamiltonian(n_qubits=nqubits)
         qaoa_descriptor = QAOADescriptor(cost_hamil, mixer_hamil, p=p)
-        variate_params = QAOAVariationalStandardParams(qaoa_descriptor, betas, gammas)
+
+        # Try instantiating the variate params
+        _ = QAOAVariationalStandardParams(qaoa_descriptor, betas, gammas)
 
         # If the user's aws credentials is not correct.
         mock_device = Mock()
@@ -383,10 +382,8 @@ class TestingQAOABraketQPUBackend(unittest.TestCase):
 
         QAOAAWSQPUBackend(qaoa_descriptor, aws_device, shots, None, None, True, 1.0)
 
-
-    @pytest.mark.braket_api            
+    @pytest.mark.braket_api
     def test_remote_qubit_overflow(self):
-
         """
         If the user creates a circuit that is larger than the maximum circuit size
         that is supported by the QPU. An Exception should be raised with the
@@ -417,9 +414,8 @@ class TestingQAOABraketQPUBackend(unittest.TestCase):
                 "There are lesser qubits on the device than the number of qubits required for the circuit.",
             )
 
-    @pytest.mark.qpu
+    @pytest.mark.sim
     def test_remote_integration_qpu_run(self):
-
         """
         Run a toy example in manual mode to make sure everything works as
         expected for a remote backend

--- a/tests/test_qpu_qiskit.py
+++ b/tests/test_qpu_qiskit.py
@@ -24,131 +24,153 @@ from openqaoa_qiskit.backends import (
 )
 from openqaoa.utilities import X_mixer_hamiltonian
 from openqaoa.problems import NumberPartition
-from openqaoa import QAOA
+from openqaoa import QAOA, create_device
 
 
 class TestingQAOAQiskitQPUBackendAzure(unittest.TestCase):
-    
-    """This Object tests the QAOA Qiskit QPU Backend object with the Azure 
+
+    """This Object tests the QAOA Qiskit QPU Backend object with the Azure
     Device object. This checks that the use of qiskit to send circuits to Azure
     is working as intended.
-    
+
     The Azure CLI has to be configured beforehand to run these tests.
     """
-    
+
     @pytest.mark.api
     def setUp(self):
-        
+        """
+        Setting up the credentials
+        """
         bashCommand = "az resource list"
         process = subprocess.Popen(bashCommand.split(), stdout=subprocess.PIPE)
         output, error = process.communicate()
-        
+
         if error is not None:
             print(error)
-            raise Exception('You must have the Azure CLI installed and must be logged in to use the Azure Quantum Backends')
+            raise Exception(
+                "You must have the Azure CLI installed and must be logged in to use the Azure Quantum Backends"
+            )
         else:
             output_json = json.loads(output)
-            output_json_s = [each_json for each_json in output_json if each_json['name'] == 'TestingOpenQAOA'][0]
-            self.RESOURCE_ID = output_json_s['id']
-            self.AZ_LOCATION = output_json_s['location']
-            
+            output_json_s = [
+                each_json
+                for each_json in output_json
+                if each_json["name"] == "TestingOpenQAOA"
+            ][0]
+            self.RESOURCE_ID = output_json_s["id"]
+            self.AZ_LOCATION = output_json_s["location"]
+
     @pytest.mark.sim
     def check_shots_tally(self):
-        
-        """There is a known bug in the qiskit backend for azure where if the shots 
-        argument might be ignored. This test checks that the output from the azure 
+        """
+        There is a known bug in the qiskit backend for azure where if the shots
+        argument might be ignored. This test checks that the output from the azure
         computation matches the input requirements.
         """
-        
+
         shots = 1024
         problem_qubo = NumberPartition([1, 2, 3]).qubo
-        azure_device = create_device(location='azure', name='rigetti.sim.qvm', 
-                                     resource_id=self.RESOURCE_ID, 
-                                     az_location=self.AZ_LOCATION)
-        
+        azure_device = create_device(
+            location="azure",
+            name="rigetti.sim.qvm",
+            resource_id=self.RESOURCE_ID,
+            az_location=self.AZ_LOCATION,
+        )
+
         q = QAOA()
         q.set_device(azure_device)
         q.set_backend_properties(n_shots=shots)
-        q.set_classical_optimizer(maxiter = 1)
+        q.set_classical_optimizer(maxiter=1)
         q.compile(problem_qubo)
         q.optimize()
-        
-        comp_shots = sum(q.result.optimized['optimized measurement outcomes'].values())
-        
+
+        q.dump(file_name="check_shots_tally", prepend_id=False, overwrite=True)
+
+        comp_shots = sum(q.result.optimized["optimized measurement outcomes"].values())
+
         self.assertEqual(shots, comp_shots)
-        
+
     @pytest.mark.api
     def test_expectations_in_init(self):
-        
         """
         Testing the Exceptions in the init function of the QiskitQPUShotBasedBackend
         """
-        
+
         nqubits = 3
         p = 1
         weights = [1, 1, 1]
-        gammas = [1/8*np.pi]
-        betas = [1/8*np.pi]
+        gammas = [1 / 8 * np.pi]
+        betas = [1 / 8 * np.pi]
         shots = 10000
 
-        cost_hamil = Hamiltonian([PauliOp('ZZ', (0, 1)), PauliOp('ZZ', (1, 2)),
-                                  PauliOp('ZZ', (0, 2))], weights, 1)
+        cost_hamil = Hamiltonian(
+            [PauliOp("ZZ", (0, 1)), PauliOp("ZZ", (1, 2)), PauliOp("ZZ", (0, 2))],
+            weights,
+            1,
+        )
         mixer_hamil = X_mixer_hamiltonian(n_qubits=nqubits)
         qaoa_descriptor = QAOADescriptor(cost_hamil, mixer_hamil, p=p)
-        variate_params = QAOAVariationalStandardParams(qaoa_descriptor,
-                                                       betas, gammas)
-        
-        # We mock the potential Exception that could occur in the Device class
-        azure_device = DeviceAzure('', '', '')
-        azure_device._check_provider_connection = Mock(return_value=False)
-        
-        try:
-            QAOAQiskitQPUBackend(qaoa_descriptor, azure_device, 
-                                 shots, None, None, True)
-        except Exception as e:
-            self.assertEqual(str(e), 'Error connecting to AZURE.')
-        
-        with self.assertRaises(Exception):
-            QAOAQiskitQPUBackend(qaoa_descriptor, azure_device, shots, None, None, True)
-        
 
-        azure_device = DeviceAzure(device_name='', resource_id=self.RESOURCE_ID, 
-                                   az_location=self.AZ_LOCATION)
-        
+        # Try to compute the variate params
+        _ = QAOAVariationalStandardParams(qaoa_descriptor, betas, gammas)
+
+        # We mock the potential Exception that could occur in the Device class
+        azure_device = DeviceAzure("", "", "")
+        azure_device._check_provider_connection = Mock(return_value=False)
+
         try:
-            QAOAQiskitQPUBackend(qaoa_descriptor, azure_device, 
-                                 shots, None, None, True)
+            QAOAQiskitQPUBackend(qaoa_descriptor, azure_device, shots, None, None, True)
         except Exception as e:
-            self.assertEqual(str(e), 'Connection to AZURE was made. Error connecting to the specified backend.')
-        
+            self.assertEqual(str(e), "Error connecting to AZURE.")
+
         with self.assertRaises(Exception):
             QAOAQiskitQPUBackend(qaoa_descriptor, azure_device, shots, None, None, True)
-        
+
+        azure_device = DeviceAzure(
+            device_name="", resource_id=self.RESOURCE_ID, az_location=self.AZ_LOCATION
+        )
+
+        try:
+            QAOAQiskitQPUBackend(qaoa_descriptor, azure_device, shots, None, None, True)
+        except Exception as e:
+            self.assertEqual(
+                str(e),
+                "Connection to AZURE was made. Error connecting to the specified backend.",
+            )
+
+        with self.assertRaises(Exception):
+            QAOAQiskitQPUBackend(qaoa_descriptor, azure_device, shots, None, None, True)
+
     @pytest.mark.api
     def test_remote_qubit_overflow(self):
-        
         """
         If the user creates a circuit that is larger than the maximum circuit size
-        that is supported by the QPU. An Exception should be raised with the 
+        that is supported by the QPU. An Exception should be raised with the
         appropriate error message alerting the user to the error.
         """
-        
+
         shots = 100
-        
+
         set_of_numbers = np.random.randint(1, 10, 6).tolist()
         qubo = NumberPartition(set_of_numbers).qubo
 
         mixer_hamil = X_mixer_hamiltonian(n_qubits=6)
         qaoa_descriptor = QAOADescriptor(qubo.hamiltonian, mixer_hamil, p=1)
-        variate_params = create_qaoa_variational_params(qaoa_descriptor, 'standard', 'rand')
 
-        azure_device = DeviceAzure('rigetti.sim.qvm', self.RESOURCE_ID, self.AZ_LOCATION)
-        
+        # Check the creation of the varitional parms
+        _ = create_qaoa_variational_params(qaoa_descriptor, "standard", "rand")
+
+        azure_device = DeviceAzure(
+            "rigetti.sim.qvm", self.RESOURCE_ID, self.AZ_LOCATION
+        )
+
         try:
-            QAOAQiskitQPUBackend(qaoa_descriptor, azure_device, 
-                                 shots, None, None, True)
+            QAOAQiskitQPUBackend(qaoa_descriptor, azure_device, shots, None, None, True)
         except Exception as e:
-            self.assertEqual(str(e), 'There are lesser qubits on the device than the number of qubits required for the circuit.')
+            self.assertEqual(
+                str(e),
+                "There are lesser qubits on the device than the number of qubits required for the circuit.",
+            )
 
 
 class TestingQAOAQiskitQPUBackend(unittest.TestCase):
@@ -156,13 +178,15 @@ class TestingQAOAQiskitQPUBackend(unittest.TestCase):
     """This Object tests the QAOA Qiskit QPU Backend objects, which is tasked with the
     creation and execution of a QAOA circuit for the selected QPU provider and
     backend.
-    
+
     IBMQ Account has to be saved locally to run these tests.
     """
 
     @pytest.mark.api
     def setUp(self):
-
+        """
+        Define the credentials
+        """
         self.HUB = "ibm-q"
         self.GROUP = "open"
         self.PROJECT = "main"
@@ -417,7 +441,6 @@ class TestingQAOAQiskitQPUBackend(unittest.TestCase):
 
     @pytest.mark.api
     def test_expectations_in_init(self):
-
         """
         Testing the Exceptions in the init function of the QiskitQPUShotBasedBackend
         """
@@ -436,7 +459,9 @@ class TestingQAOAQiskitQPUBackend(unittest.TestCase):
         )
         mixer_hamil = X_mixer_hamiltonian(n_qubits=nqubits)
         qaoa_descriptor = QAOADescriptor(cost_hamil, mixer_hamil, p=p)
-        variate_params = QAOAVariationalStandardParams(qaoa_descriptor, betas, gammas)
+
+        # Check the creation of the varitional parms
+        _ = QAOAVariationalStandardParams(qaoa_descriptor, betas, gammas)
 
         # We mock the potential Exception that could occur in the Device class
         qiskit_device = DeviceQiskit("", "", "", "")
@@ -501,7 +526,6 @@ class TestingQAOAQiskitQPUBackend(unittest.TestCase):
         shots = 10000
 
         for i in range(4):
-
             cost_hamil = Hamiltonian(
                 [PauliOp("ZZ", (0, 1)), PauliOp("ZZ", (1, 2)), PauliOp("ZZ", (0, 2))],
                 weights,
@@ -536,7 +560,6 @@ class TestingQAOAQiskitQPUBackend(unittest.TestCase):
 
     @pytest.mark.api
     def test_remote_qubit_overflow(self):
-
         """
         If the user creates a circuit that is larger than the maximum circuit size
         that is supported by the QPU. An Exception should be raised with the
@@ -550,9 +573,9 @@ class TestingQAOAQiskitQPUBackend(unittest.TestCase):
 
         mixer_hamil = X_mixer_hamiltonian(n_qubits=6)
         qaoa_descriptor = QAOADescriptor(qubo.hamiltonian, mixer_hamil, p=1)
-        variate_params = create_qaoa_variational_params(
-            qaoa_descriptor, "standard", "rand"
-        )
+
+        # Check the creation of the varitional parms
+        _ = create_qaoa_variational_params(qaoa_descriptor, "standard", "rand")
 
         qiskit_device = DeviceQiskit("ibmq_manila", self.HUB, self.GROUP, self.PROJECT)
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -778,7 +778,7 @@ class TestingVanillaQAOA(unittest.TestCase):
         qaoa.set_header(
             project_id="8353185c-b175-4eda-9628-b4e58cb0e41b",
             description="test",
-            run_by="raul",
+            run_by="OpenQAOA",
             provider="-",
             target="vectorized",
             cloud="local",
@@ -797,7 +797,7 @@ class TestingVanillaQAOA(unittest.TestCase):
         qaoa.set_header(
             project_id="8353185c-b175-4eda-9628-b4e58cb0e41b",
             description="test",
-            run_by="raul",
+            run_by="OpenQAOA",
             provider="-",
             target="vectorized",
             cloud="local",
@@ -812,7 +812,7 @@ class TestingVanillaQAOA(unittest.TestCase):
             "project_id": "8353185c-b175-4eda-9628-b4e58cb0e41b",
             "algorithm": "qaoa",
             "description": "test",
-            "run_by": "raul",
+            "run_by": "OpenQAOA",
             "provider": "-",
             "target": "vectorized",
             "cloud": "local",
@@ -877,7 +877,7 @@ class TestingVanillaQAOA(unittest.TestCase):
             qaoa.set_header(
                 project_id="test",
                 description="test",
-                run_by="raul",
+                run_by="OpenQAOA",
                 provider="-",
                 target="vectorized",
                 cloud="local",
@@ -894,7 +894,7 @@ class TestingVanillaQAOA(unittest.TestCase):
                 project_id="8353185c-b175-4eda-9628-b4e58cb0e41b",
                 experiment_id="test",
                 description="test",
-                run_by="raul",
+                run_by="OpenQAOA",
                 provider="-",
                 target="vectorized",
                 cloud="local",
@@ -977,7 +977,7 @@ class TestingVanillaQAOA(unittest.TestCase):
         qaoa.set_header(
             project_id="8353185c-b175-4eda-9628-b4e58cb0e41b",
             description="test",
-            run_by="raul",
+            run_by="OpenQAOA",
             provider="-",
             target="vectorized",
             cloud="local",
@@ -1677,7 +1677,7 @@ class TestingRQAOA(unittest.TestCase):
         r.set_header(
             project_id="8353185c-b175-4eda-9628-b4e58cb0e41b",
             description="header",
-            run_by="raul",
+            run_by="OpenQAOA",
             client="-",
         )
         r.set_exp_tags(tags={"tag1": "value1", "tag2": "value2"})
@@ -2513,7 +2513,7 @@ class TestingRQAOA(unittest.TestCase):
             r.set_header(
                 project_id="8353185c-b175-4eda-9628-b4e58cb0e41b",
                 description="test",
-                run_by="raul",
+                run_by="OpenQAOA",
                 provider="-",
                 target="vectorized",
                 cloud="local",

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,4 +1,6 @@
-import json, os, gzip
+import json
+import os
+import gzip
 import unittest
 import networkx as nw
 import numpy as np
@@ -10,6 +12,7 @@ from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer import QasmSimulator
 
 from openqaoa import QAOA, RQAOA
+from openqaoa.problems import NumberPartition
 from openqaoa.algorithms import QAOAResult, RQAOAResult
 from openqaoa.algorithms.baseworkflow import Workflow
 from openqaoa.utilities import X_mixer_hamiltonian, XY_mixer_hamiltonian, is_valid_uuid
@@ -21,7 +24,8 @@ from openqaoa.algorithms.workflow_properties import (
 from openqaoa.algorithms.rqaoa.rqaoa_workflow_properties import RqaoaParameters
 from openqaoa.backends import create_device, DeviceLocal
 from openqaoa.backends.cost_function import cost_function
-from openqaoa.backends.devices_core import SUPPORTED_LOCAL_SIMULATORS
+
+# from openqaoa.backends.devices_core import SUPPORTED_LOCAL_SIMULATORS
 from openqaoa.qaoa_components import (
     Hamiltonian,
     QAOADescriptor,
@@ -53,14 +57,11 @@ from openqaoa_azure.backends import DeviceAzure
 from openqaoa.qaoa_components.variational_parameters.variational_params_factory import (
     PARAMS_CLASSES_MAPPER,
 )
-ALLOWED_LOCAL_SIMUALTORS = SUPPORTED_LOCAL_SIMULATORS
-LOCAL_DEVICES = ALLOWED_LOCAL_SIMUALTORS + ["6q-qvm", "Aspen-11"]
 
 
 def _compare_qaoa_results(dict_old, dict_new):
-
     for key in dict_old.keys():
-        if key == "cost_hamiltonian":  ## CHECK WHAT DO WITH THIS
+        if key == "cost_hamiltonian":  # CHECK WHAT DO WITH THIS
             pass
         elif key == "_QAOAResult__type_backend":
             if issubclass(dict_old[key], QAOABaseBackendStatevector):
@@ -96,7 +97,8 @@ def _compare_qaoa_results(dict_old, dict_new):
 
 def _test_keys_in_dict(obj, expected_keys):
     """
-    private function to test the keys. It recursively tests the keys of the nested dictionaries, or lists of dictionaries
+    private function to test the keys.
+    It recursively tests the keys of the nested dictionaries, or lists of dictionaries
     """
 
     if isinstance(obj, dict):
@@ -121,7 +123,6 @@ class TestingVanillaQAOA(unittest.TestCase):
     """
 
     def test_vanilla_qaoa_default_values(self):
-
         q = QAOA()
         assert q.circuit_properties.p == 1
         assert q.circuit_properties.param_type == "standard"
@@ -130,7 +131,6 @@ class TestingVanillaQAOA(unittest.TestCase):
         assert q.device.device_name == "vectorized"
 
     def test_end_to_end_vectorized(self):
-
         g = nw.circulant_graph(6, [1])
         vc = MinimumVertexCover(g, field=1.0, penalty=10).qubo
 
@@ -177,22 +177,22 @@ class TestingVanillaQAOA(unittest.TestCase):
             )
         )
         assert type(q.device) == DeviceQiskit
-        assert q.device.device_name == 'place_holder'
-        assert q.device.device_location ==  'ibmq'
-        
-        
-        q.set_device(create_device('azure', name='place_holder', resource_id='***', 
-                                   az_location='***'))
+        assert q.device.device_name == "place_holder"
+        assert q.device.device_location == "ibmq"
+
+        q.set_device(
+            create_device(
+                "azure", name="place_holder", resource_id="***", az_location="***"
+            )
+        )
         assert type(q.device) == DeviceAzure
-        assert q.device.device_name == 'place_holder'
-        assert q.device.device_location == 'azure'
+        assert q.device.device_name == "place_holder"
+        assert q.device.device_location == "azure"
 
     def test_compile_before_optimise(self):
         """
         Assert that compilation has to be called before optimisation
         """
-        g = nw.circulant_graph(6, [1])
-        # vc = MinimumVertexCover(g, field =1.0, penalty=10).qubo
 
         q = QAOA()
         q.set_classical_optimizer(optimization_progress=True)
@@ -200,7 +200,6 @@ class TestingVanillaQAOA(unittest.TestCase):
         self.assertRaises(ValueError, lambda: q.optimize())
 
     def test_cost_hamil(self):
-
         g = nw.circulant_graph(6, [1])
         problem = MinimumVertexCover(g, field=1.0, penalty=10)
         qubo_problem = problem.qubo
@@ -221,7 +220,6 @@ class TestingVanillaQAOA(unittest.TestCase):
         )
 
     def test_set_circuit_properties_fourier_q(self):
-
         """
         The value of q should be None if the param_type used is not fourier.
         Else if param_type is fourier, fourier_extended or fourier_w_bias, it
@@ -241,7 +239,6 @@ class TestingVanillaQAOA(unittest.TestCase):
         self.assertEqual(q.circuit_properties.q, None)
 
     def test_set_circuit_properties_annealing_time_linear_ramp_time(self):
-
         """
         Check that linear_ramp_time and annealing_time are updated appropriately
         as the value of p is changed.
@@ -260,9 +257,9 @@ class TestingVanillaQAOA(unittest.TestCase):
         self.assertEqual(q.circuit_properties.linear_ramp_time, 0.7 * 2)
 
     def test_set_circuit_properties_qaoa_descriptor_mixer_x(self):
-
         """
-        Checks if the X mixer created by the X_mixer_hamiltonian method and the automated methods in workflows do the same thing.
+        Checks if the X mixer created by the X_mixer_hamiltonian method
+        and the automated methods in workflows do the same thing.
 
         For each qubit, there should be 1 RXGateMap per layer of p.
         """
@@ -294,9 +291,9 @@ class TestingVanillaQAOA(unittest.TestCase):
                 self.assertEqual(q.qaoa_descriptor.mixer_blocks[j][i].qubit_1, i)
 
     def test_set_circuit_properties_qaoa_descriptor_mixer_xy(self):
-
         """
-        Checks if the XY mixer created by the XY_mixer_hamiltonian method and the automated methods in workflows do the same thing.
+        Checks if the XY mixer created by the XY_mixer_hamiltonian method
+        and the automated methods in workflows do the same thing.
 
         Depending on the qubit connectivity selected. (chain, full or star)
         For each pair of connected qubits, there should be 1 RXXGateMap and RYYGateMap per layer of p.
@@ -340,7 +337,6 @@ class TestingVanillaQAOA(unittest.TestCase):
                 )
 
     def test_set_circuit_properties_variate_params(self):
-
         """
         Ensure that the Varitional Parameter Object created based on the input string , param_type, is correct.
 
@@ -370,7 +366,6 @@ class TestingVanillaQAOA(unittest.TestCase):
         problem = MinimumVertexCover(g, field=1.0, penalty=10)
 
         for i in range(len(object_types)):
-
             q = QAOA()
             q.set_circuit_properties(param_type=param_type_names[i], q=1)
 
@@ -379,7 +374,6 @@ class TestingVanillaQAOA(unittest.TestCase):
             self.assertEqual(type(q.variate_params), object_types[i])
 
     def test_set_circuit_properties_change(self):
-
         """
         Ensure that once a property has beefn changed via set_circuit_properties.
         The attribute has been appropriately updated.
@@ -427,9 +421,9 @@ class TestingVanillaQAOA(unittest.TestCase):
             self.assertEqual(getattr(q.circuit_properties, each_key), each_value)
 
     def test_set_circuit_properties_rejected_values(self):
-
         """
-        Some properties of CircuitProperties Object return a ValueError if the specified property has not been whitelisted in the code.
+        Some properties of CircuitProperties Object return a ValueError
+        if the specified property has not been whitelisted in the code.
         This checks that the ValueError is raised if the argument is not whitelisted.
         """
 
@@ -447,7 +441,6 @@ class TestingVanillaQAOA(unittest.TestCase):
         self.assertRaises(ValueError, lambda: q.set_circuit_properties(p=-1))
 
     def test_set_backend_properties_change(self):
-
         """
         Ensure that once a property has been changed via set_backend_properties.
         The attribute has been appropriately updated.
@@ -481,7 +474,6 @@ class TestingVanillaQAOA(unittest.TestCase):
             self.assertEqual(getattr(q.backend_properties, each_key), each_value)
 
     def test_set_backend_properties_check_backend_vectorized(self):
-
         """
         Check if the backend returned by set_backend_properties is correct
         Based on the input device.
@@ -508,7 +500,6 @@ class TestingVanillaQAOA(unittest.TestCase):
         self.assertRaises(AttributeError, lambda: q.backend.n_shots)
 
     def test_set_backend_properties_check_backend_vectorized_w_custom(self):
-
         """
         Check if the backend returned by set_backend_properties is correct
         Based on the input device.
@@ -550,7 +541,6 @@ class TestingVanillaQAOA(unittest.TestCase):
         self.assertRaises(AttributeError, lambda: q.backend.n_shots)
 
     def test_set_backend_properties_check_backend_vectorized_error_values(self):
-
         """
         If the values provided from the workflows are incorrect, we should
         receive the appropriate error messages from the vectorized backend.
@@ -588,7 +578,6 @@ class TestingVanillaQAOA(unittest.TestCase):
         self.assertRaises(ValueError, lambda: q.compile(problem=qubo_problem))
 
     def test_set_backend_properties_check_backend_qiskit_qasm(self):
-
         """
         Check if the backend returned by set_backend_properties is correct
         Based on the input device. For qiskit qasm simulator.
@@ -614,7 +603,6 @@ class TestingVanillaQAOA(unittest.TestCase):
         self.assertEqual(q.backend.n_shots, 100)
 
     def test_set_backend_properties_check_backend_qiskit_statevector(self):
-
         """
         Check if the backend returned by set_backend_properties is correct
         Based on the input device. For qiskit statevector simulator.
@@ -643,7 +631,6 @@ class TestingVanillaQAOA(unittest.TestCase):
         self.assertRaises(AttributeError, lambda: q.backend.n_shots)
 
     def test_set_backend_properties_check_backend_pyquil_statevector(self):
-
         """
         Check if the backend returned by set_backend_properties is correct
         Based on the input device. For pyquil statevector simulator.
@@ -672,7 +659,6 @@ class TestingVanillaQAOA(unittest.TestCase):
         self.assertRaises(AttributeError, lambda: q.backend.n_shots)
 
     def test_set_classical_optimizer_defaults(self):
-
         """
         Check if the fields in the default classical_optimizer dict are correct
         """
@@ -699,11 +685,10 @@ class TestingVanillaQAOA(unittest.TestCase):
         for each_key, each_value in default_pairings.items():
             self.assertEqual(getattr(q.classical_optimizer, each_key), each_value)
 
-            if each_value != None:
-                self.assertEqual(q.classical_optimizer.asdict()[each_key], each_value)
+            # if each_value is None: LD --> I don't think we really need this test, since asdict()
+            #     assert isinstance(q.classical_optimizer.each_key, None)
 
     def test_set_classical_optimizer_jac_hess_casing(self):
-
         """
         jac and hess should be in lower case if it is a string.
         """
@@ -715,7 +700,6 @@ class TestingVanillaQAOA(unittest.TestCase):
         self.assertEqual(q.classical_optimizer.hess, "hess")
 
     def test_set_classical_optimizer_method_selectors(self):
-
         """
         Different methods would return different Optimizer classes.
         Check that the correct class is returned.
@@ -780,7 +764,7 @@ class TestingVanillaQAOA(unittest.TestCase):
                 assert qaoa.header["algorithm"] == "qaoa"
             else:
                 assert (
-                    value == None
+                    value is None
                 ), "The value of the key {} (of the dictionary qaoa.header) is not None, when it should be.".format(
                     key
                 )
@@ -819,7 +803,8 @@ class TestingVanillaQAOA(unittest.TestCase):
             experiment_id=experiment_id,
         )
 
-        # check if the header values are set to the correct values, except for the qubit_number, atomic_id, execution_time_start, and execution_time_end (which are set to None)
+        # check if the header values are set to the correct values, except for the
+        # qubit_number, atomic_id, execution_time_start, and execution_time_end (which are set to None)
         dict_values = {
             "experiment_id": experiment_id,
             "project_id": "8353185c-b175-4eda-9628-b4e58cb0e41b",
@@ -845,8 +830,10 @@ class TestingVanillaQAOA(unittest.TestCase):
         # compile the QAOA object
         qaoa.compile(problem=QUBO.random_instance(n=8))
 
-        # check if the header values are still set to the correct values, except for execution_time_start, and execution_time_end (which are set to None).
-        # Now atomic_id should be set to a valid uuid. And qubit_number should be set to 8 (number of qubits of the problem)
+        # check if the header values are still set to the correct values, except for execution_time_start, and
+        # execution_time_end (which are set to None).
+        # Now atomic_id should be set to a valid uuid.
+        # And qubit_number should be set to 8 (number of qubits of the problem)
         dict_values["qubit_number"] = 8
         for key, value in qaoa.header.items():
             if key not in ["atomic_id"]:
@@ -865,7 +852,8 @@ class TestingVanillaQAOA(unittest.TestCase):
         # optimize the QAOA object
         qaoa.optimize()
 
-        # check if the header values are still set to the correct values, now everything should be set to a valid value (execution_time_start and execution_time_end should be integers>1672933928)
+        # check if the header values are still set to the correct values, now everything should be set to a valid value
+        # (execution_time_start and execution_time_end should be integers>1672933928)
         dict_values["atomic_id"] = atomic_id
         for key, value in qaoa.header.items():
             if key not in ["execution_time_start", "execution_time_end"]:
@@ -1199,11 +1187,11 @@ class TestingVanillaQAOA(unittest.TestCase):
         for key, value in expected_keys.items():
             if key not in exclude_keys:
                 assert (
-                    value == True
+                    value is True
                 ), f'Key "{key}" not found in the dictionary, when using "{method}" method.'
             else:
                 assert (
-                    value == False
+                    value is False
                 ), f'Key "{key}" was found in the dictionary, but it should not be there, when using "{method}" method.'
 
         """
@@ -1245,7 +1233,6 @@ class TestingVanillaQAOA(unittest.TestCase):
             create_device(location="local", name="qiskit.shot_simulator"),
             create_device(location="local", name="vectorized"),
         ]:
-
             q = QAOA()
             q.set_device(device)
             q.set_circuit_properties(
@@ -1278,9 +1265,9 @@ class TestingVanillaQAOA(unittest.TestCase):
 
             qaoas.append(q)
 
-        # for each rqaoa object, create a new rqaoa object from dict, json string, json file, and compressed json file and compare them with the original object
+        # for each rqaoa object, create a new rqaoa object from dict, json string, json file,
+        # and compressed json file and compare them with the original object
         for q in qaoas:
-
             new_q_list = []
 
             # get new qaoa from dict
@@ -1297,7 +1284,6 @@ class TestingVanillaQAOA(unittest.TestCase):
             os.remove("test.json.gz")  # delete file test.json
 
             for new_q in new_q_list:
-
                 # check that the new object is an QAOA object
                 assert isinstance(new_q, QAOA), "new_r is not an RQAOA object"
 
@@ -1372,7 +1358,6 @@ class TestingVanillaQAOA(unittest.TestCase):
 
         # for each qaoa object, test the evaluate_circuit method
         for q in qaoas:
-
             # evaluate the circuit with random dict of params
             params = {
                 k: np.random.rand(*v.shape)
@@ -1381,36 +1366,45 @@ class TestingVanillaQAOA(unittest.TestCase):
             result = q.evaluate_circuit(params)
             assert (
                 abs(result["cost"]) >= 0
-            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should return a cost, here cost is {result['cost']}"
+            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` \
+                should return a cost, here cost is {result['cost']}"
             assert (
                 abs(result["uncertainty"]) > 0
-            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should return an uncertanty, here uncertainty is {result['uncertainty']}"
+            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should return an uncertanty, \
+                here uncertainty is {result['uncertainty']}"
             assert (
                 len(result["measurement_results"]) > 0
-            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should return a wavefunction when using a state-based simulator"
+            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should return \
+                a wavefunction when using a state-based simulator"
 
-            # evaluate the circuit with a list of params, taking the params from the dict, so we should get the same result
+            # evaluate the circuit with a list of params, taking the params from the dict,
+            # so we should get the same result
             params2 = []
             for value in params.values():
                 params2 += value.flatten().tolist()
             result2 = q.evaluate_circuit(params2)
             assert (
                 result == result2
-            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should return the same result when passing a dict or a list of params"
+            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should return the same result \
+                when passing a dict or a list of params"
 
-            # evaluate the circuit with np.ndarray of params, taking the params from the dict, so we should get the same result
+            # evaluate the circuit with np.ndarray of params, taking the params from the dict,
+            # so we should get the same result
             result2 = q.evaluate_circuit(np.array(params2))
             assert (
                 result == result2
-            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should return the same result when passing a dict or a list of params"
+            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should return the same result \
+                when passing a dict or a list of params"
 
-            # evaluate the circuit with the params as a QAOAVariationalBaseParams object, so we should get the same result
+            # evaluate the circuit with the params as a QAOAVariationalBaseParams object,
+            # so we should get the same result
             params_obj = deepcopy(q.variate_params)
             params_obj.update_from_raw(params2)
             result3 = q.evaluate_circuit(params_obj)
             assert (
                 result == result3
-            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should return the same result when passing a dict or a list of params"
+            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should return the same result \
+                when passing a dict or a list of params"
 
             # run the circuit with the params manually, we should get the same result
             result4 = {}
@@ -1421,7 +1415,8 @@ class TestingVanillaQAOA(unittest.TestCase):
             result4["measurement_results"] = q.backend.wavefunction(params_obj)
             assert (
                 result == result4
-            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should return the same result when passing the optimized params manually"
+            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should return the same result when \
+                  passing the optimized params manually"
 
             # evaluate the circuit with a wrong input, it should raise an error
             error = False
@@ -1431,7 +1426,8 @@ class TestingVanillaQAOA(unittest.TestCase):
                 error = True
             assert (
                 error
-            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should raise an error when passing a wrong input"
+            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should raise an error when \
+                  passing a wrong input"
 
             # evaluate the circuit with a list longer than it should, it should raise an error
             error = False
@@ -1441,7 +1437,8 @@ class TestingVanillaQAOA(unittest.TestCase):
                 error = True
             assert (
                 error
-            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should raise an error when passing a list longer than it should"
+            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should raise an error when \
+                passing a list longer than it should"
 
             # evaluate the circuit with a list shorter than it should, it should raise an error
             error = False
@@ -1451,7 +1448,8 @@ class TestingVanillaQAOA(unittest.TestCase):
                 error = True
             assert (
                 error
-            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should raise an error when passing a list shorter than it should"
+            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should raise an error when \
+                passing a list shorter than it should"
 
             # evaluate the circuit with a dict with a wrong key, it should raise an error
             error = False
@@ -1461,7 +1459,8 @@ class TestingVanillaQAOA(unittest.TestCase):
                 error = True
             assert (
                 error
-            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should raise an error when passing a dict with a wrong key"
+            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should raise an error \
+                when passing a dict with a wrong key"
 
             # evaluate the circuit with a dict with a value longer than it should, it should raise an error
             error = False
@@ -1473,7 +1472,8 @@ class TestingVanillaQAOA(unittest.TestCase):
                 error = True
             assert (
                 error
-            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should raise an error when passing a dict with a value longer than it should"
+            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should raise an error when \
+                passing a dict with a value longer than it should"
 
             # evaluate the circuit without passing any param, it should raise an error
             error = False
@@ -1483,7 +1483,8 @@ class TestingVanillaQAOA(unittest.TestCase):
                 error = True
             assert (
                 error
-            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should raise an error when not passing any param"
+            ), f"param_type={q.circuit_properties.param_type}. `evaluate_circuit` should raise an error when \
+                  not passing any param"
 
         # check that it works with shots
         q = QAOA()
@@ -1543,10 +1544,10 @@ class TestingVanillaQAOA(unittest.TestCase):
             abs(result["cost"]) >= 0
         ), "When using an analytical simulator, `evaluate_circuit` should return a cost"
         assert (
-            result["uncertainty"] == None
+            result["uncertainty"] is None
         ), "When using an analytical simulator, `evaluate_circuit` should return uncertainty None"
         assert (
-            result["measurement_results"] == None
+            result["measurement_results"] is None
         ), "When using an analytical simulator, `evaluate_circuit` should return no measurement results"
 
     def test_change_properties_after_compilation(self):
@@ -1567,6 +1568,19 @@ class TestingVanillaQAOA(unittest.TestCase):
                 maxiter=100, method="vgd", jac="finite_difference"
             )
 
+    def test_numpy_serialize(self):
+        np_qubo = NumberPartition([1, 2, 3]).qubo
+
+        q = QAOA()
+        q.compile(np_qubo)
+        q.optimize()
+
+        # add numpy results
+        numpy_res = {"000": np.int64(85), "100": np.int64(85), "010": np.int64(85)}
+        q.result.optimized["measurement_outcomes"] = numpy_res
+
+        q.dumps()
+
 
 class TestingRQAOA(unittest.TestCase):
     """
@@ -1583,7 +1597,7 @@ class TestingRQAOA(unittest.TestCase):
         assert cp.param_type == "standard"
         assert cp.init_type == "ramp"
         assert cp.p == 1
-        assert cp.q == None
+        assert cp.q is None
         assert cp.mixer_hamiltonian == "x"
 
         # device
@@ -1601,7 +1615,7 @@ class TestingRQAOA(unittest.TestCase):
         assert r.rqaoa_parameters.n_cutoff == 5
         assert r.rqaoa_parameters.n_max == 1
         assert r.rqaoa_parameters.steps == 1
-        assert r.rqaoa_parameters.original_hamiltonian == None
+        assert r.rqaoa_parameters.original_hamiltonian is None
         assert r.rqaoa_parameters.counter == 0
 
         self._test_default_values(r)
@@ -1629,8 +1643,7 @@ class TestingRQAOA(unittest.TestCase):
         name_device="qiskit.statevector_simulator",
         return_object=False,
     ):
-
-        if problem == None:
+        if problem is None:
             problem = MaximumCut.random_instance(
                 n_nodes=8, edge_probability=0.5, seed=2
             ).qubo
@@ -1701,7 +1714,6 @@ class TestingRQAOA(unittest.TestCase):
         ), "RQAOA should not be able to optimize twice without compilation"
 
     def test_example_1_adaptive_custom(self):
-
         # Number of qubits
         n_qubits = 12
 
@@ -1739,7 +1751,6 @@ class TestingRQAOA(unittest.TestCase):
                 assert solution[key] == exact_soutions[key]
 
     def test_example_2_adaptive_custom(self):
-
         # Elimination scheme
         n_cutoff = 3
 
@@ -1761,7 +1772,6 @@ class TestingRQAOA(unittest.TestCase):
                 assert solution[key] == exact_soutions[key]
 
     def test_example_3_adaptive_custom(self):
-
         # Elimination scheme
         step = 2
         nmax = 4
@@ -1796,7 +1806,6 @@ class TestingRQAOA(unittest.TestCase):
                 assert solution[key] == exact_soutions[key]
 
     def test_example_4_adaptive_custom(self):
-
         # Number of qubits
         n_qubits = 10
 
@@ -2326,11 +2335,11 @@ class TestingRQAOA(unittest.TestCase):
         for key, value in expected_keys.items():
             if key not in exclude_keys:
                 assert (
-                    value == True
+                    value is True
                 ), f'Key "{key}" not found in the dictionary, when using "{method}" method.'
             else:
                 assert (
-                    value == False
+                    value is False
                 ), f'Key "{key}" was found in the dictionary, but it should not be there, when using "{method}" method.'
 
         """
@@ -2426,11 +2435,9 @@ class TestingRQAOA(unittest.TestCase):
 
         # check if the files have the expected keys
         for atomic_id, dictionary in files.items():
-
             file_name = file_names[atomic_id]
 
             if r.header["atomic_id"] == atomic_id:  # rqaoa files
-
                 rqaoa_files += 1
 
                 assert (
@@ -2451,7 +2458,6 @@ class TestingRQAOA(unittest.TestCase):
                     ), f"File {file_name} has intermediate mesuraments, but it should not have them."
 
             else:  # qaoa files
-
                 qaoa_files += 1
 
                 assert (
@@ -2497,7 +2503,6 @@ class TestingRQAOA(unittest.TestCase):
             create_device(location="local", name="qiskit.shot_simulator"),
             create_device(location="local", name="vectorized"),
         ]:
-
             r = RQAOA()
             r.set_device(device)
             r.set_circuit_properties(
@@ -2531,9 +2536,9 @@ class TestingRQAOA(unittest.TestCase):
 
             rqaoas.append(r)
 
-        # for each rqaoa object, create a new rqaoa object from dict, json string, json file, and compressed json file and compare them with the original object
+        # for each rqaoa object, create a new rqaoa object from dict, json string, json file,
+        # and compressed json file and compare them with the original object
         for r in rqaoas:
-
             new_r_list = []
 
             # get new qaoa from dict
@@ -2550,7 +2555,6 @@ class TestingRQAOA(unittest.TestCase):
             os.remove("test.json.gz")  # delete file test.json
 
             for new_r in new_r_list:
-
                 # check that the new object is an RQAOA object
                 assert isinstance(new_r, RQAOA), "new_r is not an RQAOA object"
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -86,11 +86,13 @@ def _compare_qaoa_results(dict_old, dict_new):
                     for step in range(len(dict_old[key][key2])):
                         assert np.all(
                             dict_old[key][key2][step] == dict_new[key][key2][step]
-                        ), "Intermediate params are not the same."
+                        ), f"Intermediate params are not the same. Expected {dict_old[key][key2][step]} but \
+                            received {dict_new[key][key2][step]}"
                 else:
                     assert (
                         dict_old[key][key2] == dict_new[key][key2]
-                    ), "Intermediate params are not the same."
+                    ), f"Intermediate params are not the same. Expected {dict_old[key][key2]}, but \
+                        received {dict_new[key][key2]}"
         else:
             assert dict_old[key] == dict_new[key], f"'{key}' is not the same"
 
@@ -778,7 +780,7 @@ class TestingVanillaQAOA(unittest.TestCase):
             description="test",
             run_by="raul",
             provider="-",
-            target="-",
+            target="vectorized",
             cloud="local",
             client="-",
         )
@@ -797,7 +799,7 @@ class TestingVanillaQAOA(unittest.TestCase):
             description="test",
             run_by="raul",
             provider="-",
-            target="-",
+            target="vectorized",
             cloud="local",
             client="-",
             experiment_id=experiment_id,
@@ -812,7 +814,7 @@ class TestingVanillaQAOA(unittest.TestCase):
             "description": "test",
             "run_by": "raul",
             "provider": "-",
-            "target": "-",
+            "target": "vectorized",
             "cloud": "local",
             "client": "-",
             "qubit_number": None,
@@ -877,7 +879,7 @@ class TestingVanillaQAOA(unittest.TestCase):
                 description="test",
                 run_by="raul",
                 provider="-",
-                target="-",
+                target="vectorized",
                 cloud="local",
                 client="-",
             )
@@ -894,7 +896,7 @@ class TestingVanillaQAOA(unittest.TestCase):
                 description="test",
                 run_by="raul",
                 provider="-",
-                target="-",
+                target="vectorized",
                 cloud="local",
                 client="-",
             )
@@ -913,10 +915,17 @@ class TestingVanillaQAOA(unittest.TestCase):
         qaoa.compile(problem=QUBO.random_instance(n=8))
         qaoa.optimize()
 
-        assert qaoa.exp_tags == {
+        tags = {
             "tag1": "value9",
             "tag2": "value2",
-        }, "Experiment tags are not set correctly."
+            "init_type": "ramp",
+            "optimizer_method": "cobyla",
+            "p": 1,
+            "param_type": "standard",
+            "qubit_number": 8,
+        }
+
+        assert qaoa.exp_tags == tags, "Experiment tags are not set correctly."
 
         error = False
         try:
@@ -970,7 +979,7 @@ class TestingVanillaQAOA(unittest.TestCase):
             description="test",
             run_by="raul",
             provider="-",
-            target="-",
+            target="vectorized",
             cloud="local",
             client="-",
         )
@@ -1239,15 +1248,12 @@ class TestingVanillaQAOA(unittest.TestCase):
                 p=1, param_type="extended", init_type="rand", mixer_hamiltonian="x"
             )
             q.set_backend_properties(n_shots=50)
-            q.set_classical_optimizer(maxiter=10, optimization_progress=True)
+            q.set_classical_optimizer(maxiter=2, optimization_progress=True)
             q.set_exp_tags({"add_tag": "test"})
             q.set_header(
                 project_id="8353185c-b175-4eda-9628-b4e58cb0e41b",
                 description="test",
-                run_by="raul",
-                provider="-",
-                target="-",
-                cloud="local",
+                run_by="oq",
                 client="-",
             )
 
@@ -1672,9 +1678,6 @@ class TestingRQAOA(unittest.TestCase):
             project_id="8353185c-b175-4eda-9628-b4e58cb0e41b",
             description="header",
             run_by="raul",
-            provider="-",
-            target="-",
-            cloud="local",
             client="-",
         )
         r.set_exp_tags(tags={"tag1": "value1", "tag2": "value2"})
@@ -2399,7 +2402,7 @@ class TestingRQAOA(unittest.TestCase):
         )
 
         # create list of expected file names
-        project_id = "None"
+        project_id = "d3a6f03b-1484-423a-8432-38e57c4e9ec7"
         experiment_id, atomic_id = r.header["experiment_id"], r.header["atomic_id"]
         file_names = {
             id: project_id
@@ -2517,7 +2520,7 @@ class TestingRQAOA(unittest.TestCase):
                 description="test",
                 run_by="raul",
                 provider="-",
-                target="-",
+                target="vectorized",
                 cloud="local",
                 client="-",
             )

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2372,22 +2372,18 @@ class TestingRQAOA(unittest.TestCase):
         test dumping the RQAOA object step by step
         """
 
+        project_id = "d3a6f03b-1484-423a-8432-38e57c4e9ec7"
+
         # define the problem
         problem = QUBO.random_instance(n=8)
         problem.set_metadata(
             {"metadata_key1": "metadata_value1", "metadata_key2": "metadata_value2"}
         )
 
-        # define the RQAOA object
         r = RQAOA()
-
-        # set experimental tags
+        r.set_header(project_id=project_id)
         r.set_exp_tags({"tag1": "value1", "tag2": "value2"})
-
-        # set the classical optimizer
         r.set_classical_optimizer(optimization_progress=True)
-
-        # compile the problem
         r.compile(problem)
 
         # optimize the problem while dumping the data at each step
@@ -2402,7 +2398,6 @@ class TestingRQAOA(unittest.TestCase):
         )
 
         # create list of expected file names
-        project_id = "d3a6f03b-1484-423a-8432-38e57c4e9ec7"
         experiment_id, atomic_id = r.header["experiment_id"], r.header["atomic_id"]
         file_names = {
             id: project_id

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1582,8 +1582,28 @@ class TestingVanillaQAOA(unittest.TestCase):
         q.optimize()
 
         # add numpy results
-        numpy_res = {"000": np.int64(85), "100": np.int64(85), "010": np.int64(85)}
-        q.result.optimized["measurement_outcomes"] = numpy_res
+        numpy_dict = {
+            "000": np.int64(85),
+            "100": np.int64(85),
+            "010": np.int64(85),
+            "111": 12,
+        }
+        numpy_cost = np.float64(85.123)
+
+        q.result.optimized["intermediate"] = [
+            numpy_cost,
+            numpy_cost,
+            numpy_cost,
+            0.123,
+            -123.123,
+        ]
+        q.result.intermediate["measurement_outcomes"] = [
+            numpy_dict,
+            numpy_dict,
+            numpy_dict,
+        ]
+        q.result.optimized["measurement_outcomes"] = numpy_dict
+        q.result.optimized["cost"] = numpy_cost
 
         q.dumps()
 


### PR DESCRIPTION
## Description

Bug Fixes and Enhancements:
 - `q.dump` was not working for some backends. The issue was the wrong serialization of numpy values (measurement results and costs, both in the intermediate and in the optimized result)
 - Target and Cloud in the header are now automatically inferred
 - Some standard QAOA values are automatically added to the header's metadata
 - function naming
 - variable names
 - fix some issues related to flake8 

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [x] I have performed a self-review of my code.
- [x] I have commented my code and used numpy-style docstrings
- [x] I have made corresponding updates to the documentation.
- [x] My changes generate no new warnings
- [x I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

