### PR TITLE
Fixes #234: Add `brute_force` method to the QAOA Workflow class

### DIFF
--- a/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
+++ b/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
@@ -1,4 +1,4 @@
-from typing import List, Callable, Optional, Union, Dict
+from typing import List, Callable, Optional, Union, Dict, Tuple
 from copy import deepcopy
 import numpy as np
 
@@ -17,7 +17,7 @@ from ...qaoa_components import (
 from ...qaoa_components.variational_parameters.variational_baseparams import (
     QAOAVariationalBaseParams,
 )
-from ...utilities import get_mixer_hamiltonian, generate_timestamp
+from ...utilities import get_mixer_hamiltonian, generate_timestamp, ground_state_hamiltonian
 from ...optimizers.qaoa_optimizer import get_optimizer
 
 
@@ -57,7 +57,7 @@ class QAOA(Workflow):
     mixer_hamil: Hamiltonian
         The desired mixer hamiltonian
     cost_hamil: Hamiltonian
-        The desired mixer hamiltonian
+        The desired cost hamiltonian
     qaoa_descriptor: QAOADescriptor
         the abstract and backend-agnostic representation of the underlying QAOA parameters
     variate_params: QAOAVariationalBaseParams
@@ -323,6 +323,24 @@ class QAOA(Workflow):
         if verbose:
             print("Optimization completed.")
         return
+    
+    def brute_force(self):
+        """
+        Computes the exact ground state and ground state energy of the cost hamiltonian.
+
+        Returns
+        -------
+        min_energy: `float`
+            The minimum eigenvalue of the cost Hamiltonian.
+
+        config: `np.array`
+            The minimum energy eigenvector as a binary array
+            configuration: qubit-0 as the first element in the sequence.
+        """
+        if self.compiled is False:
+            raise ValueError("Please compile the QAOA before brute-forcing it!")
+        return ground_state_hamiltonian(self.cost_hamil, bounded=True)
+
 
     def evaluate_circuit(
         self,

--- a/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
+++ b/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
@@ -57,7 +57,7 @@ class QAOA(Workflow):
     mixer_hamil: Hamiltonian
         The desired mixer hamiltonian
     cost_hamil: Hamiltonian
-        The desired cost hamiltonian
+        The cost hamiltonian
     qaoa_descriptor: QAOADescriptor
         the abstract and backend-agnostic representation of the underlying QAOA parameters
     variate_params: QAOAVariationalBaseParams

--- a/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
+++ b/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
@@ -1,4 +1,4 @@
-from typing import List, Callable, Optional, Union, Dict, Tuple
+from typing import List, Callable, Optional, Union, Dict
 from copy import deepcopy
 import numpy as np
 

--- a/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
+++ b/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
@@ -324,9 +324,16 @@ class QAOA(Workflow):
             print("Optimization completed.")
         return
     
-    def brute_force(self):
+    def brute_force(self, bounded=True):
         """
         Computes the exact ground state and ground state energy of the cost hamiltonian.
+
+        Parameters
+        ----------
+        bounded: `bool`, optional
+            If set to True, the function will not perform computations for qubit
+            numbers above 25. If False, the user can specify any number. Defaults
+            to True.
 
         Returns
         -------
@@ -339,7 +346,7 @@ class QAOA(Workflow):
         """
         if self.compiled is False:
             raise ValueError("Please compile the QAOA before brute-forcing it!")
-        return ground_state_hamiltonian(self.cost_hamil, bounded=True)
+        return ground_state_hamiltonian(self.cost_hamil, bounded=bounded)
 
 
     def evaluate_circuit(

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1372,6 +1372,19 @@ class TestingVanillaQAOA(unittest.TestCase):
             error = True
         assert(error), f"An uncompiled QAOA should raise an error when brute-forcing it"
 
+        # Check if bounded=True disallows computation for more than 25 qubits
+        qaoa = QAOA()
+        large_problem = MaximumCut.random_instance(
+            n_nodes=26, edge_probability=1
+        ).qubo
+        qaoa.compile(large_problem)
+        error = False
+        try:
+            (min_energy_bf, config_strings_bf) = qaoa.brute_force()
+        except:
+            error = True
+        assert(error), f"Brute forcing should not compute for large problems (> 25 qubits) when bounded=True"
+
 
 
     def test_qaoa_evaluate_circuit(self):

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -15,7 +15,7 @@ from openqaoa import QAOA, RQAOA
 from openqaoa.problems import NumberPartition
 from openqaoa.algorithms import QAOAResult, RQAOAResult
 from openqaoa.algorithms.baseworkflow import Workflow
-from openqaoa.utilities import X_mixer_hamiltonian, XY_mixer_hamiltonian, is_valid_uuid
+from openqaoa.utilities import X_mixer_hamiltonian, XY_mixer_hamiltonian, is_valid_uuid, ground_state_hamiltonian
 from openqaoa.algorithms.workflow_properties import (
     BackendProperties,
     ClassicalOptimizer,
@@ -1343,6 +1343,36 @@ class TestingVanillaQAOA(unittest.TestCase):
         assert (
             error
         ), "RQAOA.from_dict should raise an error when using a QAOA dictionary"
+
+
+    def test_qaoa_brute_force(self):
+        """
+        test the brute_force method
+        """
+        # problem
+        problem = MinimumVertexCover.random_instance(
+            n_nodes=6, edge_probability=0.8
+        ).qubo
+
+        # check if the brute force method gets the same results as the ground state hamiltonian method
+        qaoa = QAOA()
+        qaoa.compile(problem)
+        (min_energy_bf, config_strings_bf) = qaoa.brute_force()
+        (min_energy_gsh, config_strings_ghs) = ground_state_hamiltonian(qaoa.cost_hamil)
+        assert (
+            min_energy_bf == min_energy_gsh and config_strings_bf == config_strings_ghs
+        ), f"The energy and config strings of brute forcing should match the ground state hamiltonian method results"
+
+        # Check if an uncompiled QAOA raises an error when calling its brute_force method
+        qaoa_uncompiled = QAOA()
+        error = False
+        try:
+            qaoa_uncompiled.brute_force()
+        except Exception:
+            error = True
+        assert(error), f"An uncompiled QAOA should raise an error when brute-forcing it"
+
+
 
     def test_qaoa_evaluate_circuit(self):
         """


### PR DESCRIPTION
## Description

We can now call `QAOA.brute_force()` to brute force the ground state of its cost Hamiltonian.

- [x] Previous and new tests pass locally

## Description

- Fixes #234 
- Added to the QAOA Workflow class,  a new method `brute_force()` that indirectly computes the ground state energy of the QAOA Hamiltonian.
- Kept the `bounded` default parameter from the `ground_state_hamiltonian` method, hence the original 25 qubit limit

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [x] I have performed a self-review of my code.
- [x] I have commented my code and used numpy-style docstrings
- [x] I have made corresponding updates to the documentation.
- [x] My changes generate no new warnings
- [x] I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Added a test in `test_workflows.py`  called `test_brute_force` which checks that:
- The result of the computed ground state still matches the one from ground_state_hamiltonian
- An uncompiled QAOA's `test_brute_force` raises an error
- The `bounded` parameter still acts as it used to with `utilities.ground_state_hamiltonian` and raises an error when necessary
