### PR TITLE
Fixes issue #209: Handling argument list containing `0`s in `NumberPartition`

### DIFF
--- a/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
+++ b/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
@@ -1,4 +1,4 @@
-from typing import List, Callable, Optional, Union, Dict
+from typing import List, Callable, Optional, Union, Dict, Tuple
 from copy import deepcopy
 import numpy as np
 
@@ -17,7 +17,7 @@ from ...qaoa_components import (
 from ...qaoa_components.variational_parameters.variational_baseparams import (
     QAOAVariationalBaseParams,
 )
-from ...utilities import get_mixer_hamiltonian, generate_timestamp
+from ...utilities import get_mixer_hamiltonian, generate_timestamp, ground_state_hamiltonian
 from ...optimizers.qaoa_optimizer import get_optimizer
 
 
@@ -57,7 +57,7 @@ class QAOA(Workflow):
     mixer_hamil: Hamiltonian
         The desired mixer hamiltonian
     cost_hamil: Hamiltonian
-        The desired mixer hamiltonian
+        The desired cost hamiltonian
     qaoa_descriptor: QAOADescriptor
         the abstract and backend-agnostic representation of the underlying QAOA parameters
     variate_params: QAOAVariationalBaseParams
@@ -323,6 +323,24 @@ class QAOA(Workflow):
         if verbose:
             print("Optimization completed.")
         return
+    
+    def brute_force(self):
+        """
+        Computes the exact ground state and ground state energy of the cost hamiltonian.
+
+        Returns
+        -------
+        min_energy: `float`
+            The minimum eigenvalue of the cost Hamiltonian.
+
+        config: `np.array`
+            The minimum energy eigenvector as a binary array
+            configuration: qubit-0 as the first element in the sequence.
+        """
+        if self.compiled is False:
+            raise ValueError("Please compile the QAOA before brute-forcing it!")
+        return ground_state_hamiltonian(self.cost_hamil, bounded=True)
+
 
     def evaluate_circuit(
         self,

--- a/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
+++ b/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
@@ -57,7 +57,7 @@ class QAOA(Workflow):
     mixer_hamil: Hamiltonian
         The desired mixer hamiltonian
     cost_hamil: Hamiltonian
-        The desired cost hamiltonian
+        The cost hamiltonian
     qaoa_descriptor: QAOADescriptor
         the abstract and backend-agnostic representation of the underlying QAOA parameters
     variate_params: QAOAVariationalBaseParams

--- a/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
+++ b/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
@@ -1,4 +1,4 @@
-from typing import List, Callable, Optional, Union, Dict, Tuple
+from typing import List, Callable, Optional, Union, Dict
 from copy import deepcopy
 import numpy as np
 

--- a/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
+++ b/src/openqaoa-core/algorithms/qaoa/qaoa_workflow.py
@@ -324,9 +324,16 @@ class QAOA(Workflow):
             print("Optimization completed.")
         return
     
-    def brute_force(self):
+    def brute_force(self, bounded=True):
         """
         Computes the exact ground state and ground state energy of the cost hamiltonian.
+
+        Parameters
+        ----------
+        bounded: `bool`, optional
+            If set to True, the function will not perform computations for qubit
+            numbers above 25. If False, the user can specify any number. Defaults
+            to True.
 
         Returns
         -------
@@ -339,7 +346,7 @@ class QAOA(Workflow):
         """
         if self.compiled is False:
             raise ValueError("Please compile the QAOA before brute-forcing it!")
-        return ground_state_hamiltonian(self.cost_hamil, bounded=True)
+        return ground_state_hamiltonian(self.cost_hamil, bounded=bounded)
 
 
     def evaluate_circuit(

--- a/src/openqaoa-core/problems/numberpartition.py
+++ b/src/openqaoa-core/problems/numberpartition.py
@@ -21,9 +21,15 @@ class NumberPartition(Problem):
 
     __name__ = "number_partition"
 
-    def __init__(self, numbers=None):
-        # Set the numbers to be partitioned. If not given, generate a random list with integers
-        self.numbers = numbers
+    def __init__(self, numbers=None, keep0=False):
+
+        # Set the numbers to be partitioned.
+        if 0 in numbers and keep0 is False:
+            print("Warning: Omitting zeros in the numbers list. Instantiate with keep0=True to keep 0 terms.")
+            self.numbers = list(filter(lambda elem: elem is not 0, numbers))
+        else:
+            self.numbers = numbers
+
         self.n_numbers = None if numbers == None else len(self.numbers)
 
     @property

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -2,8 +2,6 @@ import unittest
 import networkx as nx
 import numpy as np
 from random import randint, random
-from io import StringIO
-import sys
 from openqaoa.problems import (
     NumberPartition,
     QUBO,

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -2,6 +2,8 @@ import unittest
 import networkx as nx
 import numpy as np
 from random import randint, random
+from io import StringIO
+import sys
 from openqaoa.problems import (
     NumberPartition,
     QUBO,
@@ -229,6 +231,52 @@ class TestProblem(unittest.TestCase):
         ), "Should have thrown an error when setting key qubo problem instance that is not json serializable"
 
     # TESTING NUMBER PARITION CLASS
+
+    def test_number_partitioning_handles_0_in_numbers(self):
+        """Test that the init function removes zeros from the list if not specified otherwise"""
+        # Check that instantiating with a list containing a 0 with keep0=True will not alter the list
+        list_numbers_with_0 = [0, 1, 2, 3]
+        np = NumberPartition(list_numbers_with_0, keep0=True)
+        assert (
+            np.numbers == list_numbers_with_0
+        ), f"The list should not be altered when keep0 is True"
+        # Check that n_numbers stays consistent
+        assert (
+            np.n_numbers == 4
+        ), f"n_numbers should be the same as the list's length when passed with keep0=True"
+
+        # Check that instantiating with default keep0=False will alter the list when the list contains 0
+        np = NumberPartition(list_numbers_with_0)
+        assert (
+            np.numbers == [1, 2, 3]
+        ), f"The numbers list should not be altered when the list does not contain 0"
+
+        # Check if n_numbers is still consistent
+        assert(
+            np.n_numbers == 3
+        ), f"n_numbers should not not change when the list does not contain 0"
+
+        list_number_without_0 = [1, 2, 3]
+        # Check that instantiating with default keep0=False will not alter the list when the list does not contain 0
+        np = NumberPartition(list_number_without_0)
+        assert (
+            np.numbers == [1, 2, 3]
+        ), f"The numbers list should not be altered when the list does not contain 0"
+        # Check if n_numbers is still consistent
+        assert (
+            np.n_numbers == 3
+        ), f"n_numbers should not change when the list does not contain 0"
+
+        # Check that instantiating with multiple 0s will remove them all
+        list_number_with_multiple_0s = [0, 1, 0, 2, 0, 3]
+        np = NumberPartition(list_number_with_multiple_0s)
+        assert (
+            np.numbers == [1, 2, 3]
+        ), f"The numbers list should remove all 0s when keep0 is True and the list contains at least two 0s"
+        assert (
+            np.n_numbers == 3
+        ), f"n_numbers should update when keep0 is True and the list contains at least two 0s"
+
 
     def test_number_partitioning_terms_weights_constant(self):
         """Test that Number Partitioning creates the correct terms, weights, constant"""

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1372,6 +1372,19 @@ class TestingVanillaQAOA(unittest.TestCase):
             error = True
         assert(error), f"An uncompiled QAOA should raise an error when brute-forcing it"
 
+        # Check if bounded=True disallows computation for more than 25 qubits
+        qaoa = QAOA()
+        large_problem = MaximumCut.random_instance(
+            n_nodes=26, edge_probability=1
+        ).qubo
+        qaoa.compile(large_problem)
+        error = False
+        try:
+            (min_energy_bf, config_strings_bf) = qaoa.brute_force()
+        except:
+            error = True
+        assert(error), f"Brute forcing should not compute for large problems (> 25 qubits) when bounded=True"
+
 
 
     def test_qaoa_evaluate_circuit(self):

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -15,7 +15,7 @@ from openqaoa import QAOA, RQAOA
 from openqaoa.problems import NumberPartition
 from openqaoa.algorithms import QAOAResult, RQAOAResult
 from openqaoa.algorithms.baseworkflow import Workflow
-from openqaoa.utilities import X_mixer_hamiltonian, XY_mixer_hamiltonian, is_valid_uuid
+from openqaoa.utilities import X_mixer_hamiltonian, XY_mixer_hamiltonian, is_valid_uuid, ground_state_hamiltonian
 from openqaoa.algorithms.workflow_properties import (
     BackendProperties,
     ClassicalOptimizer,
@@ -1343,6 +1343,36 @@ class TestingVanillaQAOA(unittest.TestCase):
         assert (
             error
         ), "RQAOA.from_dict should raise an error when using a QAOA dictionary"
+
+
+    def test_qaoa_brute_force(self):
+        """
+        test the brute_force method
+        """
+        # problem
+        problem = MinimumVertexCover.random_instance(
+            n_nodes=6, edge_probability=0.8
+        ).qubo
+
+        # check if the brute force method gets the same results as the ground state hamiltonian method
+        qaoa = QAOA()
+        qaoa.compile(problem)
+        (min_energy_bf, config_strings_bf) = qaoa.brute_force()
+        (min_energy_gsh, config_strings_ghs) = ground_state_hamiltonian(qaoa.cost_hamil)
+        assert (
+            min_energy_bf == min_energy_gsh and config_strings_bf == config_strings_ghs
+        ), f"The energy and config strings of brute forcing should match the ground state hamiltonian method results"
+
+        # Check if an uncompiled QAOA raises an error when calling its brute_force method
+        qaoa_uncompiled = QAOA()
+        error = False
+        try:
+            qaoa_uncompiled.brute_force()
+        except Exception:
+            error = True
+        assert(error), f"An uncompiled QAOA should raise an error when brute-forcing it"
+
+
 
     def test_qaoa_evaluate_circuit(self):
         """


### PR DESCRIPTION
## Description

- Instantiating NumberPartition with a list that contains at least one `0`, i.e. `[0, 3, 7, 9]` will show a warning: ```Warning: Omitting zeros in the numbers list. Instantiate with keep0=True to keep 0 terms.``` 
and remove the 0s from the list, unless the user specifically states to keep the zeros by instantiating `NumberPartition` with the `keep0=True` argument (`False` by default). 
- If `keep0=True` but the list does not contain any `0`s, then the list remains unchanged.
- If `keep0=True` and the list contains at least one `0`, then no warning is displayed and the list remains unchanged.
- **Fixes** #209

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code and used numpy-style docstrings
- [x] I have made corresponding updates to the documentation.
- [x] My changes generate no new warnings
- [x] I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

[//]: <> (- [ ] Any dependent changes have been merged and published in downstream modules)

## Type of change
- [ ] New feature (non-breaking change which adds functionality) [optimization]

## How Has This Been Tested?
- Tested locally by manually instantiating different cases of NumberPartition and changing the list arguments and `keep0` to see the functionality outside unit tests.
- Written unit tests for different cases that cover the code additions

Name the new unit-tests that you have added along with this change.
In `test_problems.py`, added a unit test `test_number_partitioning_handles_0_in_numbers()`