### PR TITLE
Fixes #209: Handling argument list containing `0`s in `NumberPartition`

### DIFF
--- a/src/openqaoa-core/problems/numberpartition.py
+++ b/src/openqaoa-core/problems/numberpartition.py
@@ -21,9 +21,15 @@ class NumberPartition(Problem):
 
     __name__ = "number_partition"
 
-    def __init__(self, numbers=None):
-        # Set the numbers to be partitioned. If not given, generate a random list with integers
-        self.numbers = numbers
+    def __init__(self, numbers=None, keep0=False):
+
+        # Set the numbers to be partitioned.
+        if 0 in numbers and keep0 is False:
+            print("Warning: Omitting zeros in the numbers list. Instantiate with keep0=True to keep 0 terms.")
+            self.numbers = list(filter(lambda elem: elem is not 0, numbers))
+        else:
+            self.numbers = numbers
+
         self.n_numbers = None if numbers == None else len(self.numbers)
 
     @property

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -230,6 +230,52 @@ class TestProblem(unittest.TestCase):
 
     # TESTING NUMBER PARITION CLASS
 
+    def test_number_partitioning_handles_0_in_numbers(self):
+        """Test that the init function removes zeros from the list if not specified otherwise"""
+        # Check that instantiating with a list containing a 0 with keep0=True will not alter the list
+        list_numbers_with_0 = [0, 1, 2, 3]
+        np = NumberPartition(list_numbers_with_0, keep0=True)
+        assert (
+            np.numbers == list_numbers_with_0
+        ), f"The list should not be altered when keep0 is True"
+        # Check that n_numbers stays consistent
+        assert (
+            np.n_numbers == 4
+        ), f"n_numbers should be the same as the list's length when passed with keep0=True"
+
+        # Check that instantiating with default keep0=False will alter the list when the list contains 0
+        np = NumberPartition(list_numbers_with_0)
+        assert (
+            np.numbers == [1, 2, 3]
+        ), f"The numbers list should not be altered when the list does not contain 0"
+
+        # Check if n_numbers is still consistent
+        assert(
+            np.n_numbers == 3
+        ), f"n_numbers should not not change when the list does not contain 0"
+
+        list_number_without_0 = [1, 2, 3]
+        # Check that instantiating with default keep0=False will not alter the list when the list does not contain 0
+        np = NumberPartition(list_number_without_0)
+        assert (
+            np.numbers == [1, 2, 3]
+        ), f"The numbers list should not be altered when the list does not contain 0"
+        # Check if n_numbers is still consistent
+        assert (
+            np.n_numbers == 3
+        ), f"n_numbers should not change when the list does not contain 0"
+
+        # Check that instantiating with multiple 0s will remove them all
+        list_number_with_multiple_0s = [0, 1, 0, 2, 0, 3]
+        np = NumberPartition(list_number_with_multiple_0s)
+        assert (
+            np.numbers == [1, 2, 3]
+        ), f"The numbers list should remove all 0s when keep0 is True and the list contains at least two 0s"
+        assert (
+            np.n_numbers == 3
+        ), f"n_numbers should update when keep0 is True and the list contains at least two 0s"
+
+
     def test_number_partitioning_terms_weights_constant(self):
         """Test that Number Partitioning creates the correct terms, weights, constant"""
         list_numbers = [1, 2, 3]


### PR DESCRIPTION
## Description

- Instantiating NumberPartition with a list that contains at least one `0`, i.e. `[0, 3, 7, 9]` will show a warning: ```Warning: Omitting zeros in the numbers list. Instantiate with keep0=True to keep 0 terms.``` 
and remove the 0s from the list, unless the user specifically states to keep the zeros by instantiating `NumberPartition` with the `keep0=True` argument (`False` by default). 
- If `keep0=True` but the list does not contain any `0`s, then the list remains unchanged.
- If `keep0=True` and the list contains at least one `0`, then no warning is displayed and the list remains unchanged.
- Fixes #209

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code and used numpy-style docstrings
- [x] I have made corresponding updates to the documentation.
- [x] My changes generate no new warnings
- [x] I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

[//]: <> (- [ ] Any dependent changes have been merged and published in downstream modules)

## Type of change
- New feature (non-breaking change which adds functionality) [optimization]

## How Has This Been Tested?
- Tested locally by manually instantiating different cases of NumberPartition and changing the list arguments and `keep0` to see the functionality outside unit tests.
- Written unit tests for different cases that cover the code additions

Name the new unit-tests that you have added along with this change.
In `test_problems.py`, added a unit test `test_number_partitioning_handles_0_in_numbers()`
