### PR TITLE
Add result statistics on measurement outcomes in QAOAResult object

### DIFF
--- a/src/openqaoa-core/openqaoa/algorithms/qaoa/qaoa_result.py
+++ b/src/openqaoa-core/openqaoa/algorithms/qaoa/qaoa_result.py
@@ -629,3 +629,56 @@ class QAOAResult:
             ],
         }
         return best_results
+    
+    def calculate_statistics(self, include_intermediate=False) -> dict:
+        """
+        A function to calculate statistics of measurement outcomes associated with a QAOA workflow
+
+        Parameters
+        ----------
+        include_intermediate: `bool`
+            Whether it is necessary to calculate statistics for intermediate results. Defaults to False.
+        """
+        if len(self.intermediate["measurement_outcomes"]) == 0 and include_intermediate == True:
+            raise ValueError(
+                "Please specify saving intermediate measurements during optimization."
+            )
+
+        if isinstance(self.optimized["measurement_outcomes"], dict):
+            optimized_measurement_outcomes = self.optimized["measurement_outcomes"]
+        elif isinstance(self.optimized["measurement_outcomes"], np.ndarray):
+            optimized_measurement_outcomes = self.get_counts(
+                self.optimized["measurement_outcomes"]
+            )
+        else:
+            raise TypeError(
+                f"The measurement outcome {type(self.optimized['measurement_outcomes'])} is not valid."
+            )
+
+        if isinstance(self.intermediate["measurement_outcomes"], list):
+            if len(self.intermediate["measurement_outcomes"]) > 0:
+                if isinstance(self.intermediate["measurement_outcomes"][0], dict):
+                    intermediate_measurement_outcomes = self.intermediate["measurement_outcomes"]
+                elif isinstance(self.intermediate["measurement_outcomes"][0], np.ndarray):
+                    intermediate_measurement_outcomes = [self.get_counts(i) for i in self.intermediate["measurement_outcomes"]]
+                else:
+                    raise TypeError(
+                        f"The measurement outcome {type(self.intermediate['measurement_outcomes'][0])} is not valid."
+                    )
+        else:
+            raise TypeError(
+                f"The measurement outcome {type(self.intermediate['measurement_outcomes'])} is not valid."
+            )
+
+        def sorted_mean_std_deviation(counts: dict):
+            values = list(counts.values())
+            return {
+                'sorted': dict(sorted(counts.items(), key=lambda x: x[1], reverse=True)),
+                'mean': np.mean(values),
+                'std_deviation': np.std(values)
+            }
+
+        return {
+            'intermediate': [sorted_mean_std_deviation(i) for i in intermediate_measurement_outcomes] if include_intermediate else [],
+            'optimized': sorted_mean_std_deviation(optimized_measurement_outcomes)
+        }

--- a/src/openqaoa-core/openqaoa/algorithms/qaoa/qaoa_result.py
+++ b/src/openqaoa-core/openqaoa/algorithms/qaoa/qaoa_result.py
@@ -641,7 +641,8 @@ class QAOAResult:
         """
         if len(self.intermediate["measurement_outcomes"]) == 0 and include_intermediate == True:
             raise ValueError(
-                "Please specify saving intermediate measurements during optimization."
+                "The underlying QAOA object does not seem to have any intermediate measurement result. Please, consider saving "
+                "intermediate measurements during optimization by setting `optimization_progress=True` in your workflow."
             )
 
         if isinstance(self.optimized["measurement_outcomes"], dict):

--- a/src/openqaoa-core/tests/test_results.py
+++ b/src/openqaoa-core/tests/test_results.py
@@ -360,6 +360,100 @@ class TestingResultOutputs(unittest.TestCase):
                     results.__dict__, results_from_dict.__dict__, bool_cmplx_str
                 )
 
+    def test_qaoa_results_calculate_statistics_full(self):
+
+        maxcut_qubo = MaximumCut(
+            nw.generators.fast_gnp_random_graph(n=6, p=0.6, seed=42)
+        ).qubo
+
+        qaoas = []
+        for device_name in SUPPORTED_LOCAL_SIMULATORS:
+            if device_name == "analytical_simulator":
+                continue
+
+            qaoa = QAOA()
+
+            qaoa.set_device(create_device("local", device_name))
+            qaoa.set_classical_optimizer(optimization_progress=True)
+
+            qaoa.compile(maxcut_qubo)
+            qaoa.optimize()
+
+            qaoas.append(qaoa)
+
+        for qaoa in qaoas:
+            result = qaoa.result.calculate_statistics(include_intermediate=True)
+            result_optimized = result['optimized']
+            result_intermediate = result['intermediate']
+            optimized_sorted, optimized_mean, optimized_std_deviation = list(result_optimized['sorted'].values()), \
+                result_optimized['mean'], result_optimized['std_deviation']
+
+            for ri in result_intermediate:
+                intermediate_sorted, intermediate_mean, intermediate_std_deviation = list(ri['sorted'].values()), ri['mean'], ri['std_deviation']
+
+                assert all(intermediate_sorted[i] >= intermediate_sorted[i + 1] for i in range(len(intermediate_sorted) - 1)), "Counts in descending order."
+                assert intermediate_mean > 0, "Mean is greater then zero."
+                assert intermediate_std_deviation > 0, "Standard deviation is greater than zero."
+
+            assert all(optimized_sorted[i] >= optimized_sorted[i + 1] for i in range(len(optimized_sorted) - 1)), "Counts in descending order."
+            assert optimized_mean > 0, "Mean is greater then zero."
+            assert optimized_std_deviation > 0, "Standard deviation is greater than zero."
+
+    def test_qaoa_results_calculate_statistics_without_intermediate(self):
+
+        maxcut_qubo = MaximumCut(
+            nw.generators.fast_gnp_random_graph(n=6, p=0.6, seed=42)
+        ).qubo
+
+        qaoas = []
+        for device_name in SUPPORTED_LOCAL_SIMULATORS:
+            if device_name == "analytical_simulator":
+                continue
+
+            qaoa = QAOA()
+            qaoa.set_device(create_device("local", device_name))
+            qaoa.set_classical_optimizer(optimization_progress=False)
+
+            qaoa.compile(maxcut_qubo)
+            qaoa.optimize()
+
+            qaoas.append(qaoa)
+
+        for qaoa in qaoas:
+            result = qaoa.result.calculate_statistics(include_intermediate=False)
+            result_optimized = result['optimized']
+            optimized_sorted, optimized_mean, optimized_std_deviation = list(result_optimized['sorted'].values()), \
+                result_optimized['mean'], result_optimized['std_deviation']
+
+            assert result['intermediate'] == [], "Statistics for intermediate measurements are empty."
+            assert all(optimized_sorted[i] >= optimized_sorted[i + 1] for i in range(len(optimized_sorted) - 1)), "Counts in descending order."
+            assert optimized_mean > 0, "Mean is greater then zero."
+            assert optimized_std_deviation > 0, "Standard deviation is greater than zero."
+
+    def test_qaoa_results_calculate_statistics_raise_value_error(self):
+        """
+        The method raise an error if the user requires statistics on all 
+        intermediate measurement outcomes but hasn't specified saving them during optimization.
+        """
+        maxcut_qubo = MaximumCut(
+            nw.generators.fast_gnp_random_graph(n=6, p=0.6, seed=42)
+        ).qubo
+
+        qaoa = QAOA()
+        qaoa.set_device(create_device(location="local", name="vectorized"))
+        qaoa.set_classical_optimizer(optimization_progress=False)
+
+        qaoa.compile(maxcut_qubo)
+        qaoa.optimize()
+
+        try:
+            qaoa.result.calculate_statistics(include_intermediate=True)
+        except ValueError as e:
+            self.assertEqual(
+                str(e),
+                "Please specify saving intermediate measurements during optimization.",
+            )
+
 
 class TestingRQAOAResultOutputs(unittest.TestCase):
     """

--- a/src/openqaoa-core/tests/test_results.py
+++ b/src/openqaoa-core/tests/test_results.py
@@ -451,7 +451,7 @@ class TestingResultOutputs(unittest.TestCase):
         except ValueError as e:
             self.assertEqual(
                 str(e),
-                "Please specify saving intermediate measurements during optimization.",
+                "The underlying QAOA object does not seem to have any intermediate measurement result. Please, consider saving intermediate measurements during optimization by setting `optimization_progress=True` in your workflow.",
             )
 
 


### PR DESCRIPTION
## Description

This PR is for solving issue https://github.com/entropicalabs/openqaoa/issues/235.

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [x] I have performed a self-review of my code.
- [x] I have commented my code and used numpy-style docstrings
- [ ] I have made corresponding updates to the documentation.
- [x] My changes generate no new warnings
- [x] I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

[//]: <> (- [ ] Any dependent changes have been merged and published in downstream modules)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

test_qaoa_results_calculate_statistics_full, test_qaoa_results_calculate_statistics_without_intermediate, test_qaoa_results_calculate_statistics_raise_value_error.
