### PR TITLE
Added mark to twirling unittest

### DIFF
--- a/src/openqaoa-qiskit/tests/test_qiskit_backend_wrapper.py
+++ b/src/openqaoa-qiskit/tests/test_qiskit_backend_wrapper.py
@@ -41,12 +41,6 @@ def get_params():
     return qaoa_descriptor, variational_params_std
 
 
-class TestingBaseWrapper(unittest.TestCase):
-    """
-    These tests check that the methods of the wrapper around the backend are working properly.
-    """
-
-
 class TestingSPAMTwirlingWrapper(unittest.TestCase):
     """
     These tests check methods of the SPAM Twirling wrapper.
@@ -84,7 +78,8 @@ class TestingSPAMTwirlingWrapper(unittest.TestCase):
             n_batches=1,
             calibration_data_location=self.calibration_data_location,
         )
-
+    
+    @pytest.mark.qpu
     def test_wrap_any_backend(self):
         """
         Testing if the wrapper is backend-agnostic by checking if it can take


### PR DESCRIPTION
## Description

- Marked a unittest in Twirling unittests for qiskit with `qpu` as the tests requires IBM QPU credentials to run.

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings
- [x] I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

[//]: <> (- [ ] Any dependent changes have been merged and published in downstream modules)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Name the new unit-tests that you have added along with this change.
