### PR TITLE
Dev spam twirling evaluate

### DIFF
--- a/src/openqaoa-core/openqaoa/algorithms/qaoa/qaoa_workflow.py
+++ b/src/openqaoa-core/openqaoa/algorithms/qaoa/qaoa_workflow.py
@@ -402,7 +402,7 @@ class QAOA(Workflow):
         # Check the type of the input parameters and save them as a
         # QAOAVariationalBaseParams object at the variable `params_obj`
 
-        # if the parameters are passed as a dictionary we copy and update the variational parameters of the QAOA object
+            # if the parameters are passed as a dictionary we copy and update the variational parameters of the QAOA object
         if isinstance(params, dict):
             params_obj = deepcopy(self.variate_params)
             # we check that the dictionary contains all the parameters of the QAOA object that are not empty
@@ -450,6 +450,20 @@ class QAOA(Workflow):
         # if the backend is the analytical simulator, we just return the expectation value of the cost Hamiltonian
         if isinstance(self.backend, QAOABackendAnalyticalSimulator):
             output_dict.update({"cost": self.backend.expectation(params_obj)[0]})
+        # if the workflow implements SPAM Twirling, uncertainty is not implemented
+        elif isinstance(self.backend, SPAMTwirlingWrapper):
+            cost = self.backend.expectation(params_obj)
+            measurement_results = (
+                self.backend.measurement_outcomes
+                if isinstance(self.backend.measurement_outcomes, dict)
+                else self.backend.measurement_outcomes.tolist()
+            )
+            output_dict.update(
+                {
+                    "cost": cost,
+                    "measurement_results": measurement_results,
+                }
+            )
 
         else:
             cost, uncertainty = self.backend.expectation_w_uncertainty(params_obj)

--- a/src/openqaoa-core/openqaoa/algorithms/qaoa/qaoa_workflow.py
+++ b/src/openqaoa-core/openqaoa/algorithms/qaoa/qaoa_workflow.py
@@ -450,7 +450,8 @@ class QAOA(Workflow):
         # if the backend is the analytical simulator, we just return the expectation value of the cost Hamiltonian
         if isinstance(self.backend, QAOABackendAnalyticalSimulator):
             output_dict.update({"cost": self.backend.expectation(params_obj)[0]})
-        # if the workflow implements SPAM Twirling, uncertainty is not implemented
+        # if the workflow implements SPAM Twirling, 
+        # we just return the expectation value of the cost Hamiltonian and measurement outcomes
         elif isinstance(self.backend, SPAMTwirlingWrapper):
             cost = self.backend.expectation(params_obj)
             measurement_results = (

--- a/src/openqaoa-core/openqaoa/algorithms/qaoa/qaoa_workflow.py
+++ b/src/openqaoa-core/openqaoa/algorithms/qaoa/qaoa_workflow.py
@@ -472,11 +472,6 @@ class QAOA(Workflow):
             # the associated uncertainty and the measurement outcomes
             else:
                 cost, uncertainty = self.backend.expectation_w_uncertainty(params_obj)
-                measurement_results = (
-                    self.backend.measurement_outcomes
-                    if isinstance(self.backend.measurement_outcomes, dict)
-                    else self.backend.measurement_outcomes.tolist()
-                )
                 output_dict.update(
                     {
                         "cost": cost,

--- a/src/openqaoa-core/tests/test_workflows.py
+++ b/src/openqaoa-core/tests/test_workflows.py
@@ -1416,7 +1416,7 @@ class TestingVanillaQAOA(unittest.TestCase):
             ), "When using a shot-based simulator, `evaluate_circuit` should return a cost"
             assert (
                 abs(result["uncertainty"]) > 0
-            ), "When using a shot-based simulator, `evaluate_circuit` should return an uncertanty"
+            ), "When using a shot-based simulator, `evaluate_circuit` should return an uncertainty"
 
             cost = cost_function(
                 result["measurement_results"],

--- a/src/openqaoa-qiskit/openqaoa_qiskit/backends/devices.py
+++ b/src/openqaoa-qiskit/openqaoa_qiskit/backends/devices.py
@@ -33,7 +33,7 @@ class DeviceQiskit(DeviceBase):
         """The user's IBMQ account has to be authenticated through qiskit in
         order to use this backend. This can be done through `IBMQ.save_account`.
 
-        See: https://quantum-computing.ibm.com/lab/docs/iql/manage/account/ibmq
+        See: https://quantum-computing.ibm.com/lab/docs/iql/manage/account/ibmq 
 
         Parameters
         ----------
@@ -132,7 +132,7 @@ class DeviceQiskit(DeviceBase):
             print(
                 "An Exception has occured when trying to connect with the provider."
                 "Please note that you are required to set up your IBMQ account locally first."
-                "See: https://quantum-computing.ibm.com/lab/docs/iql/manage/account/ibmq"
+                "See: https://quantum-computing.ibm.com/lab/docs/iql/manage/account/ibmq "
                 "for how to save your IBMQ account locally. \n {}".format(e)
             )
             return False


### PR DESCRIPTION
## Description

- I fixed a known issue that the SPAM twirling feature has not implemented `expectation_with_uncertainty()`, calling `evaluate_circuit()` would not call the wrapper's redefinition of `expectation()` with the previous version of this code.
- The function `evaluate_circuit()` now functions correctly, further implementation of the uncertainty calculation with SPAM twirling is still possible.

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [x] I have performed a self-review of my code.
- [x] I have commented my code and used numpy-style docstrings
- [ ] I have made corresponding updates to the documentation.
- [x] My changes generate no new warnings
- [ ] I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

[/]: <> (- [ ] Any dependent changes have been merged and published in downstream modules)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


