### PR TITLE
Removed pyquil from global package

### DIFF
--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           source env/bin/activate
           ipython kernel install --name "env" --user
-          pytest tests/ src/*/tests -m 'not (qpu or sim)' --cov -n auto
+          pytest tests/ src/openqaoa-core/tests src/openqaoa-azure/tests src/openqaoa-braket/tests src/openqaoa-qiskit/tests -m 'not (qpu or sim)' --cov -n auto
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test_main_linux.yml
+++ b/.github/workflows/test_main_linux.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           source env/bin/activate
           ipython kernel install --name "env" --user
-          pytest tests/ src/*/tests -m 'not (qpu or sim)' --cov --cov-report=xml:coverage.xml
+          pytest tests/ src/openqaoa-core/tests src/openqaoa-azure/tests src/openqaoa-braket/tests src/openqaoa-qiskit/tests -m 'not (qpu or sim)' --cov --cov-report=xml:coverage.xml
           
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test_main_macos.yml
+++ b/.github/workflows/test_main_macos.yml
@@ -56,4 +56,4 @@ jobs:
         run: |
           source env/bin/activate
           ipython kernel install --user --name "env"
-          pytest tests/ src/*/tests -m 'not (qpu or api or docker_aws or braket_api or sim)'
+          pytest tests/ src/openqaoa-core/tests src/openqaoa-azure/tests src/openqaoa-braket/tests src/openqaoa-qiskit/tests -m 'not (qpu or api or docker_aws or braket_api or sim)'

--- a/.github/workflows/test_main_windows.yml
+++ b/.github/workflows/test_main_windows.yml
@@ -63,5 +63,5 @@ jobs:
         run: |
           .\env\Scripts\Activate.ps1
           ipython kernel install --name "env" --user
-          pytest \tests -m 'not (qpu or api or docker_aws or braket_api or sim)'
+          pytest tests/ src/openqaoa-core/tests src/openqaoa-azure/tests src/openqaoa-braket/tests src/openqaoa-qiskit/tests -m 'not (qpu or api or docker_aws or braket_api or sim)'
           Get-ChildItem -Directory | ForEach-Object { pytest $_.FullName -m 'not (qpu or api or docker_aws or braket_api or sim)'}

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 local-install:
 	pip install ./src/openqaoa-core
 	pip install ./src/openqaoa-qiskit
-	pip install ./src/openqaoa-pyquil
+#	pip install ./src/openqaoa-pyquil
 	pip install ./src/openqaoa-braket
 	pip install ./src/openqaoa-azure
 	pip install .
@@ -14,7 +14,7 @@ local-install:
 dev-install:
 	pip install -e ./src/openqaoa-core
 	pip install -e ./src/openqaoa-qiskit
-	pip install -e ./src/openqaoa-pyquil
+#	pip install -e ./src/openqaoa-pyquil
 	pip install -e ./src/openqaoa-braket
 	pip install -e ./src/openqaoa-azure
 	pip install -e .
@@ -23,7 +23,7 @@ dev-install:
 dev-install-tests:
 	pip install -e ./src/openqaoa-core[tests]
 	pip install -e ./src/openqaoa-qiskit
-	pip install -e ./src/openqaoa-pyquil
+#	pip install -e ./src/openqaoa-pyquil
 	pip install -e ./src/openqaoa-braket
 	pip install -e ./src/openqaoa-azure
 	pip install -e .
@@ -32,7 +32,7 @@ dev-install-tests:
 dev-install-docs:
 	pip install -e ./src/openqaoa-core[docs]
 	pip install -e ./src/openqaoa-qiskit
-	pip install -e ./src/openqaoa-pyquil
+#	pip install -e ./src/openqaoa-pyquil
 	pip install -e ./src/openqaoa-braket
 	pip install -e ./src/openqaoa-azure
 	pip install -e .
@@ -41,7 +41,7 @@ dev-install-docs:
 dev-install-all:
 	pip install -e ./src/openqaoa-core[all]
 	pip install -e ./src/openqaoa-qiskit
-	pip install -e ./src/openqaoa-pyquil
+#	pip install -e ./src/openqaoa-pyquil
 	pip install -e ./src/openqaoa-braket
 	pip install -e ./src/openqaoa-azure
 	pip install -e .

--- a/examples/community_tutorials/02_docplex_example.ipynb
+++ b/examples/community_tutorials/02_docplex_example.ipynb
@@ -1082,8 +1082,8 @@
     }
    ],
    "source": [
-    "#Specific local device usign qiskit backend\n",
-    "device = create_device(\"local\", 'pyquil.statevector_simulator')\n",
+    "#Specific local device usign local vectorized backend\n",
+    "device = create_device(\"local\", 'vectorized')\n",
     "\n",
     "#Is possible check the devices using qaoa.local_simulators, qaoa.cloud_provider\n",
     "qaoa = QAOA(device)\n",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("_version.py") as f:
 requirements = [
     f"{each_folder_name}=={version}"
     for each_folder_name in os.listdir("src")
-    if "openqaoa-" in each_folder_name
+    if ("openqaoa-" in each_folder_name and "openqaoa-pyquil" not in each_folder_name)
 ]
 
 setup(

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -17,7 +17,7 @@ class TestImports(unittest.TestCase):
         """
 
         folder_names = [
-            each_file for each_file in os.listdir("src") if "openqaoa-" in each_file
+            each_file for each_file in os.listdir("src") if ("openqaoa-" in each_file and not "openqaoa-pyquil")
         ]
 
         packages_import = []


### PR DESCRIPTION
## Description

- Remove the inclusion of `openqaoa-pyquil` from the meta package

## How Has This Been Tested?

Using regular tests, pyquil tests may be ignored when testing the meta-package