### PR TITLE
Fix CPLEX test workflow on MacOS and Windows + other test fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Check-out repository
       uses: actions/checkout@v3

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -34,7 +34,7 @@ jobs:
           python -m venv env
           source env/bin/activate
           python -m pip install --upgrade pip
-          make dev-install-tests
+          make dev-install-tests_cplex
           pip install ipykernel
       - name: Setup IBMQ account
         env:

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -34,7 +34,7 @@ jobs:
           python -m venv env
           source env/bin/activate
           python -m pip install --upgrade pip
-          make dev-install-tests_cplex
+          make dev-install-tests-cplex
           pip install ipykernel
       - name: Setup IBMQ account
         env:

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Log in with Azure
         uses: azure/login@v1
         with:
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install OpenQAOA
         run: |

--- a/.github/workflows/test_dev_ext.yml
+++ b/.github/workflows/test_dev_ext.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           source env/bin/activate
           ipython kernel install --name "env" --user
-          pytest tests/ src/*/tests/ -v -m 'not (qpu or docker_aws or api or sim or braket_api)'
+          pytest tests/ src/*/tests/ -v -m 'not (qpu or docker_aws or api or sim or braket_api or cplex)'
 
   docs-ext:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_dev_ext.yml
+++ b/.github/workflows/test_dev_ext.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install qvm
         run: |
           find /usr/lib -name "libffi.so*"
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install OpenQAOA
         run: |

--- a/.github/workflows/test_main_linux.yml
+++ b/.github/workflows/test_main_linux.yml
@@ -38,7 +38,7 @@ jobs:
           python -m venv env
           source env/bin/activate
           python -m pip install --upgrade pip
-          make dev-install-tests
+          make dev-install-tests_cplex
           pip install ipykernel
       - name: Setup IBMQ account
         env:

--- a/.github/workflows/test_main_linux.yml
+++ b/.github/workflows/test_main_linux.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ['3.8', '3.9', '3.10']
+        python: ['3.9', '3.10']
     # The type of runner that the job will run on
     runs-on:  ${{ matrix.os }}
     
@@ -86,7 +86,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version:  3.8
+          python-version:  3.9
 
       - name: Install OpenQAOA
         run: |

--- a/.github/workflows/test_main_linux.yml
+++ b/.github/workflows/test_main_linux.yml
@@ -38,7 +38,7 @@ jobs:
           python -m venv env
           source env/bin/activate
           python -m pip install --upgrade pip
-          make dev-install-tests_cplex
+          make dev-install-tests-cplex
           pip install ipykernel
       - name: Setup IBMQ account
         env:

--- a/.github/workflows/test_main_macos.yml
+++ b/.github/workflows/test_main_macos.yml
@@ -56,4 +56,4 @@ jobs:
         run: |
           source env/bin/activate
           ipython kernel install --user --name "env"
-          pytest tests/ src/*/tests -m 'not (qpu or api or docker_aws or braket_api or sim)'
+          pytest tests/ src/*/tests -m 'not (qpu or api or docker_aws or braket_api or sim or cplex)'

--- a/.github/workflows/test_main_macos.yml
+++ b/.github/workflows/test_main_macos.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10']
+        python: ['3.9', '3.10']
         forest-sdk-version: ['2.23.0']
 
     runs-on: macos-latest

--- a/.github/workflows/test_main_windows.yml
+++ b/.github/workflows/test_main_windows.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10']  
+        python: ['3.9', '3.10']  
         forest-sdk-version: [2.23.0]
 
     # Run on a Windows machine

--- a/.github/workflows/test_main_windows.yml
+++ b/.github/workflows/test_main_windows.yml
@@ -63,5 +63,5 @@ jobs:
         run: |
           .\env\Scripts\Activate.ps1
           ipython kernel install --name "env" --user
-          pytest tests/ src/*/tests -m 'not (qpu or api or docker_aws or braket_api or sim)'
-          Get-ChildItem -Directory | ForEach-Object { pytest $_.FullName -m 'not (qpu or api or docker_aws or braket_api or sim)'}
+          pytest tests/ src/*/tests -m 'not (qpu or api or docker_aws or braket_api or sim or cplex)'
+          Get-ChildItem -Directory | ForEach-Object { pytest $_.FullName -m 'not (qpu or api or docker_aws or braket_api or sim or cplex)'}

--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -11,7 +11,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest]
-          python: ['3.8', '3.9', '3.10']
+          python: ['3.9', '3.10']
     # The type of runner that the job will run on
     runs-on:  ${{ matrix.os }}
 

--- a/.github/workflows/test_pypi_prerelease.yml
+++ b/.github/workflows/test_pypi_prerelease.yml
@@ -11,7 +11,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest]
-          python: ['3.8', '3.9', '3.10', '3.11']
+          python: ['3.9', '3.10', '3.11']
     # The type of runner that the job will run on
     runs-on:  ${{ matrix.os }}
 

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ dev-install-tests:
 	pip install -e ./src/openqaoa-azure
 	pip install -e .
 
-.PHONY: dev-install-tests
-dev-install-tests:
-	pip install -e ./src/openqaoa-core[tests_cplex]
+.PHONY: dev-install-tests-cplex
+dev-install-tests-cplex:
+	pip install -e ./src/openqaoa-core[tests-cplex]
 	pip install -e ./src/openqaoa-qiskit
 	pip install -e ./src/openqaoa-pyquil
 	pip install -e ./src/openqaoa-braket

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,15 @@ dev-install-tests:
 	pip install -e ./src/openqaoa-azure
 	pip install -e .
 
+.PHONY: dev-install-tests
+dev-install-tests:
+	pip install -e ./src/openqaoa-core[tests_cplex]
+	pip install -e ./src/openqaoa-qiskit
+	pip install -e ./src/openqaoa-pyquil
+	pip install -e ./src/openqaoa-braket
+	pip install -e ./src/openqaoa-azure
+	pip install -e .
+
 .PHONY: dev-install-docs
 dev-install-docs:
 	pip install -e ./src/openqaoa-core[docs]

--- a/examples/09_RQAOA_example.ipynb
+++ b/examples/09_RQAOA_example.ipynb
@@ -339,7 +339,8 @@
     "print('terms of of the QUBO problem in recursive step 2: ', problem_2.terms)\n",
     "\n",
     "#plotting the correlation matrix\n",
-    "r.result.plot_corr_matrix(step=2)"
+    "fig, ax = r.result.plot_corr_matrix(step=2)\n",
+    "fig.show()"
    ]
   },
   {

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,4 +6,5 @@ markers =
     docker_aws: marks tests that require to build aws docker (deselect with '-m "not docker_aws"')
     braket_api: marks tests that require valid AWS credentials (no QPU) (deselect with '-m "not braket_api"')
     notebook: marks tests that run on jupyter noteboks (deselect with '-m "not notebook"')
-    sim: marks tests that run on remote Simulators (deselect with '-m "not sim"') 
+    sim: marks tests that run on remote Simulators (deselect with '-m "not sim"')
+    cplex: marks tests that require CPLEX (deselect with '-m "not cplex"')

--- a/src/openqaoa-core/openqaoa/algorithms/qaoa/qaoa_benchmark.py
+++ b/src/openqaoa-core/openqaoa/algorithms/qaoa/qaoa_benchmark.py
@@ -432,6 +432,8 @@ class QAOABenchmark:
                 1 if one_plot else sum([1 if values[key][0] else 0 for key in values])
             )
             fig, ax = plt.subplots(nrows=nrows, ncols=1, figsize=(6.5, 5 * nrows))
+        else:
+            fig = ax.get_figure()
 
         # plot the requested plots
         count_sp = 0  # counter of subplots
@@ -553,8 +555,8 @@ class QAOABenchmark:
         if ax_input is None:
             if nrows > 1:
                 fig.subplots_adjust(hspace=0.3)  # add some space between the subplots
-            plt.show()
-            plt.close(fig)
+        
+        return fig, ax
 
     @staticmethod
     def __ordered_points(n_params, n_points_axis):

--- a/src/openqaoa-core/openqaoa/algorithms/rqaoa/rqaoa_result.py
+++ b/src/openqaoa-core/openqaoa/algorithms/rqaoa/rqaoa_result.py
@@ -156,6 +156,6 @@ class RQAOAResult(dict):
             fig = ax.get_figure()
 
         ax.imshow(self.get_corr_matrix(step=step), cmap=cmap)
-        ax.colorbar()
+        fig.colorbar()
         
         return fig, ax

--- a/src/openqaoa-core/openqaoa/algorithms/rqaoa/rqaoa_result.py
+++ b/src/openqaoa-core/openqaoa/algorithms/rqaoa/rqaoa_result.py
@@ -144,11 +144,18 @@ class RQAOAResult(dict):
         """
         return self["intermediate_steps"][step]["corr_matrix"]
 
-    def plot_corr_matrix(self, step, cmap="cool"):
+    def plot_corr_matrix(self, step, cmap="cool", ax=None):
         """
         Plots the correlation matrix of the i-th step of the RQAOA.
         TODO : add more options
         """
-        plt.imshow(self.get_corr_matrix(step=step), cmap=cmap)
-        plt.colorbar()
-        plt.show()
+
+        if ax is None:
+            fig, ax = plt.subplots()
+        else:
+            fig = ax.get_figure()
+
+        ax.imshow(self.get_corr_matrix(step=step), cmap=cmap)
+        ax.colorbar()
+        
+        return fig, ax

--- a/src/openqaoa-core/openqaoa/algorithms/rqaoa/rqaoa_result.py
+++ b/src/openqaoa-core/openqaoa/algorithms/rqaoa/rqaoa_result.py
@@ -155,7 +155,7 @@ class RQAOAResult(dict):
         else:
             fig = ax.get_figure()
 
-        ax.imshow(self.get_corr_matrix(step=step), cmap=cmap)
-        fig.colorbar()
+        im = ax.imshow(self.get_corr_matrix(step=step), cmap=cmap)
+        cbar = ax.figure.colorbar(im, ax=ax)
         
         return fig, ax

--- a/src/openqaoa-core/openqaoa/problems/bpsp.py
+++ b/src/openqaoa-core/openqaoa/problems/bpsp.py
@@ -621,6 +621,8 @@ class BPSP(Problem):
         # If no ax (subplot) is provided, create a new figure with the determined width
         if ax is None:
             fig, ax = plt.subplots(figsize=(fig_width, 2))
+        else:
+            fig = ax.get_figure()
 
         # Plot bars for each car, colored based on the paint_sequence
         ax.bar(
@@ -647,7 +649,4 @@ class BPSP(Problem):
         ax.spines["right"].set_visible(False)
         ax.spines["left"].set_visible(False)
 
-        # If no ax is provided, show the plot directly
-        if ax is None:
-            plt.tight_layout()
-            plt.show()
+        return fig, ax

--- a/src/openqaoa-core/openqaoa/qaoa_components/ansatz_constructor/gatemaplabel.py
+++ b/src/openqaoa-core/openqaoa/qaoa_components/ansatz_constructor/gatemaplabel.py
@@ -55,7 +55,8 @@ class GateMapLabel:
         """
         String representation of the Gatemap label
         """
-        representation = f"{self.n_qubits}Q_" if self.n_qubits is not None else ""
+        n_str = "ONE" if self.n_qubits == 1 else "TWO" if self.n_qubits == 2 else ""
+        representation = f"{n_str}Q_" if self.n_qubits is not None else ""
         representation += f"{self.type.value}" if self.type.value is not None else ""
         representation += f"_seq{self.sequence}" if self.sequence is not None else ""
         representation += f"_layer{self.layer}" if self.layer is not None else ""

--- a/src/openqaoa-core/openqaoa/qaoa_components/ansatz_constructor/rotationangle.py
+++ b/src/openqaoa-core/openqaoa/qaoa_components/ansatz_constructor/rotationangle.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from typing import List, Union, Callable
-from gatemaplabel import GateMapLabel
 
 
 class RotationAngle(object):

--- a/src/openqaoa-core/openqaoa/qaoa_components/ansatz_constructor/rotationangle.py
+++ b/src/openqaoa-core/openqaoa/qaoa_components/ansatz_constructor/rotationangle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import List, Union, Callable
+from gatemaplabel import GateMapLabel
 
 
 class RotationAngle(object):

--- a/src/openqaoa-core/openqaoa/qaoa_components/variational_parameters/annealingparams.py
+++ b/src/openqaoa-core/openqaoa/qaoa_components/variational_parameters/annealingparams.py
@@ -155,8 +155,12 @@ class QAOAVariationalAnnealingParams(QAOAVariationalBaseParams):
     def plot(self, ax=None, **kwargs):
         if ax is None:
             fig, ax = plt.subplots()
+        else:
+            fig = ax.get_figure()
 
         ax.plot(self.schedule, marker="s", **kwargs)
         ax.set_xlabel("p", fontsize=14)
         ax.set_ylabel("s(t)", fontsize=14)
         ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+
+        return fig, ax

--- a/src/openqaoa-core/openqaoa/qaoa_components/variational_parameters/extendedparams.py
+++ b/src/openqaoa-core/openqaoa/qaoa_components/variational_parameters/extendedparams.py
@@ -306,6 +306,8 @@ class QAOAVariationalExtendedParams(QAOAVariationalBaseParams):
 
         if ax is None:
             fig, ax = plt.subplots((n + 1) // 2, 2, figsize=(9, 9 if n > 2 else 5))
+        else:
+            fig = ax.get_figure()
 
         fig.tight_layout(pad=4.0)
 
@@ -342,3 +344,5 @@ class QAOAVariationalExtendedParams(QAOAVariationalBaseParams):
             ax[1].axis("off")
         elif k == 2:
             ax[1, 1].axis("off")
+
+        return fig, ax

--- a/src/openqaoa-core/openqaoa/qaoa_components/variational_parameters/fourierparams.py
+++ b/src/openqaoa-core/openqaoa/qaoa_components/variational_parameters/fourierparams.py
@@ -198,6 +198,8 @@ class QAOAVariationalFourierParams(QAOAVariationalBaseParams):
 
         if ax is None:
             fig, ax = plt.subplots(2, figsize=(7, 9))
+        else:
+            fig = ax.get_figure()
 
         fig.tight_layout(pad=4.0)
 
@@ -212,6 +214,8 @@ class QAOAVariationalFourierParams(QAOAVariationalBaseParams):
         ax[1].set_xlabel("p")
         ax[1].legend()
         ax[1].xaxis.set_major_locator(MaxNLocator(integer=True))
+
+        return fig, ax
 
 
 class QAOAVariationalFourierWithBiasParams(QAOAVariationalBaseParams):
@@ -425,6 +429,8 @@ class QAOAVariationalFourierWithBiasParams(QAOAVariationalBaseParams):
         #              "params.u_singles, params.u_pairs")
         if ax is None:
             fig, ax = plt.subplots(2, figsize=(7, 9))
+        else:
+            fig = ax.get_figure()
 
         fig.tight_layout(pad=4.0)
 
@@ -455,6 +461,8 @@ class QAOAVariationalFourierWithBiasParams(QAOAVariationalBaseParams):
         ax[1].set_xlabel("p")
         ax[1].legend()
         ax[1].xaxis.set_major_locator(MaxNLocator(integer=True))
+
+        return fig, ax
 
 
 class QAOAVariationalFourierExtendedParams(QAOAVariationalBaseParams):
@@ -792,3 +800,5 @@ class QAOAVariationalFourierExtendedParams(QAOAVariationalBaseParams):
 
         if j == 0:
             ax[i, j + 1].axis("off")
+
+        return fig, ax

--- a/src/openqaoa-core/openqaoa/qaoa_components/variational_parameters/fourierparams.py
+++ b/src/openqaoa-core/openqaoa/qaoa_components/variational_parameters/fourierparams.py
@@ -706,19 +706,6 @@ class QAOAVariationalFourierExtendedParams(QAOAVariationalBaseParams):
         return cls(qaoa_descriptor, q, v_singles, v_pairs, u_singles, u_pairs)
 
     def plot(self, ax=None, **kwargs):
-        # if ax is None:
-        #     fig, ax = plt.subplots()
-
-        # ax.plot(dct(self.v, n=self.p, axis=0),
-        #         label="betas", marker="s", ls="", **kwargs)
-        # if not _is_iterable_empty(self.u_singles):
-        #     ax.plot(dst(self.u_singles, n=self.p),
-        #             label="gammas_singles", marker="^", ls="", **kwargs)
-        # if not _is_iterable_empty(self.u_pairs):
-        #     ax.plot(dst(self.u_pairs, n=self.p),
-        #             label="gammas_pairs", marker="v", ls="", **kwargs)
-        # ax.set_xlabel("timestep")
-        # ax.legend()
 
         betas_singles = dct(self.v_singles, n=self.p, axis=0)
         betas_pairs = dct(self.v_pairs, n=self.p, axis=0)
@@ -767,6 +754,8 @@ class QAOAVariationalFourierExtendedParams(QAOAVariationalBaseParams):
 
         if ax is None:
             fig, ax = plt.subplots((n + 1) // 2, 2, figsize=(9, 4 * (n + 1) // 2))
+        else:
+            fig = ax.get_figure()
 
         fig.tight_layout(pad=4.0)
 

--- a/src/openqaoa-core/openqaoa/qaoa_components/variational_parameters/standardparams.py
+++ b/src/openqaoa-core/openqaoa/qaoa_components/variational_parameters/standardparams.py
@@ -162,12 +162,16 @@ class QAOAVariationalStandardParams(QAOAVariationalBaseParams):
     def plot(self, ax=None, **kwargs):
         if ax is None:
             fig, ax = plt.subplots()
+        else:
+            fig = ax.get_figure()
 
         ax.plot(self.betas, label="betas", marker="s", ls="", **kwargs)
         ax.plot(self.gammas, label="gammas", marker="^", ls="", **kwargs)
         ax.set_xlabel("p", fontsize=12)
         ax.xaxis.set_major_locator(MaxNLocator(integer=True))
         ax.legend()
+
+        return fig, ax
 
     def convert_to_ext(self, args_std):
         """
@@ -382,6 +386,8 @@ class QAOAVariationalStandardWithBiasParams(QAOAVariationalBaseParams):
     def plot(self, ax=None, **kwargs):
         if ax is None:
             fig, ax = plt.subplots()
+        else:
+            fig = ax.get_figure()
 
         ax.plot(self.betas, label="betas", marker="s", ls="", **kwargs)
         if not _is_iterable_empty(self.gammas_singles):
@@ -396,3 +402,5 @@ class QAOAVariationalStandardWithBiasParams(QAOAVariationalBaseParams):
         ax.xaxis.set_major_locator(MaxNLocator(integer=True))
         # ax.grid(linestyle='--')
         ax.legend()
+
+        return fig, ax

--- a/src/openqaoa-core/openqaoa/utilities.py
+++ b/src/openqaoa-core/openqaoa/utilities.py
@@ -425,7 +425,10 @@ def plot_graph(G: nx.Graph, ax=None, colormap="seismic") -> None:
     """
 
     # Create plot figure
-    fig, ax = plt.subplots(figsize=(10, 6), ncols=1)
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(10, 6), ncols=1)
+    else:
+        fig = ax.get_figure()
 
     # Extract all graph attributes
     biases_and_nodes = nx.get_node_attributes(G, "weight")
@@ -495,10 +498,7 @@ def plot_graph(G: nx.Graph, ax=None, colormap="seismic") -> None:
             with_labels=True,
         )
 
-    # Show plot
-
-    plt.show()
-    return None
+    return fig, ax
 
 
 def random_classical_hamiltonian(
@@ -842,6 +842,8 @@ def plot_energy_spectrum(
     # If no axis provided, define figure
     if ax is None:
         fig, ax = plt.subplots(1, 1, figsize=(3, 5))
+    else:
+        fig = ax.get_figure()
 
     # Plot energy levels
     for i, energy in enumerate(unique_energies):
@@ -856,7 +858,7 @@ def plot_energy_spectrum(
     )
     ax.legend(loc="center left", fontsize=8)
 
-    return None
+    return fig, ax
 
 
 def low_energy_states(

--- a/src/openqaoa-core/requirements.txt
+++ b/src/openqaoa-core/requirements.txt
@@ -1,6 +1,6 @@
 pandas>=1.3.5
 sympy>=1.10.1
-numpy>=1.22.3
+numpy>=1.22.3,<2.0
 networkx>=2.8
 matplotlib>=3.4.3
 scipy>=1.8

--- a/src/openqaoa-core/requirements_test.txt
+++ b/src/openqaoa-core/requirements_test.txt
@@ -4,4 +4,3 @@ pytest-cov>=3.0.0
 nbconvert>=6.5.1
 pandas>=1.4.3
 plotly>=5.9.0
-cplex>=22.1.0.0

--- a/src/openqaoa-core/setup.py
+++ b/src/openqaoa-core/setup.py
@@ -41,7 +41,7 @@ setup(
     extras_require={
         "docs": requirements_docs,
         "tests": requirements_test,
-        "tests_cplex": requirements_test + ["cplex>=22.1.1"],
+        "tests-cplex": requirements_test + ["cplex>=22.1.1"],
         "all": requirements_docs + requirements_test + ["cplex>=22.1.1"],
     },
 )

--- a/src/openqaoa-core/setup.py
+++ b/src/openqaoa-core/setup.py
@@ -41,6 +41,7 @@ setup(
     extras_require={
         "docs": requirements_docs,
         "tests": requirements_test,
-        "all": requirements_docs + requirements_test,
+        "tests_cplex": requirements_test + ["cplex>=22.1.1"],
+        "all": requirements_docs + requirements_test + ["cplex>=22.1.1"],
     },
 )

--- a/src/openqaoa-core/tests/test_bin_packing.py
+++ b/src/openqaoa-core/tests/test_bin_packing.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 import numpy as np
 import matplotlib.pyplot as plt
 from openqaoa.problems import BinPacking
@@ -497,6 +498,7 @@ class TestBinPacking(unittest.TestCase):
             binpacking_manual_prob.constant, binpacking_random_prob.constant
         )
 
+    @pytest.mark.cplex
     def test_binpacking_classical_sol(self):
         """Test the Bin Packing random instance method classical solution"""
 
@@ -572,6 +574,7 @@ class TestBinPacking(unittest.TestCase):
             str(e.exception),
         )
 
+    @pytest.mark.cplex
     def test_binpacking_classical_sol_checking(self):
         """
         Checks if the unfeasible classical solution returns the right error.

--- a/src/openqaoa-core/tests/test_bpsp.py
+++ b/src/openqaoa-core/tests/test_bpsp.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 import numpy as np
 import networkx as nx
 from docplex.mp.model import Model
@@ -193,6 +194,7 @@ class TestBPSP(unittest.TestCase):
             "Objective should be of type 'minimize'",
         )
 
+    @pytest.mark.cplex
     def test_bpsp_solve_cplex(self):
         """
         Test the solution of the BPSP problem using CPLEX.

--- a/src/openqaoa-core/tests/test_kcolor.py
+++ b/src/openqaoa-core/tests/test_kcolor.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 import networkx as nx
 import numpy as np
 import matplotlib.pyplot as plt
@@ -156,6 +157,7 @@ class TestKColor(unittest.TestCase):
                 "Input problem graph must be a networkx Graph.", str(e.exception)
             )
 
+    @pytest.mark.cplex
     def test_kcolor_classical_sol(self):
         """Test the k-color random instance method classical solution"""
 
@@ -175,6 +177,7 @@ class TestKColor(unittest.TestCase):
         for i in range(n_nodes):
             self.assertTrue(kcolor_sol[i * k : (i + 1) * k].count("1") == 1)
 
+    @pytest.mark.cplex
     def test_kcolor_plot(self):
         """Test k-color random instance method"""
         seed = 1234

--- a/src/openqaoa-core/tests/test_mis.py
+++ b/src/openqaoa-core/tests/test_mis.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 import networkx as nx
 import numpy as np
 import matplotlib.pyplot as plt
@@ -98,6 +99,7 @@ class TestMIS(unittest.TestCase):
                 "Input problem graph must be a networkx Graph.", str(e.exception)
             )
 
+    @pytest.mark.cplex
     def test_mis_classical_sol(self):
         """Test the maximal independent set random instance method classical solution"""
 

--- a/src/openqaoa-core/tests/test_portfolio_optimization.py
+++ b/src/openqaoa-core/tests/test_portfolio_optimization.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 import numpy as np
 from openqaoa.problems import PortfolioOptimization
 
@@ -95,6 +96,7 @@ class TestPortfolioOptimization(unittest.TestCase):
         self.assertEqual(qubo.terms, qubo_random.terms)
         self.assertEqual(qubo.constant, qubo_random.constant)
 
+    @pytest.mark.cplex
     def test_portfoliooptimization_classical_sol(self):
         """Test the portfolio optimization set random instance method classical solution"""
 
@@ -118,6 +120,7 @@ class TestPortfolioOptimization(unittest.TestCase):
 
         self.assertEqual(po_sol, sol)
 
+    @pytest.mark.cplex
     def test_portfoliooptimization_plot(self):
         """Test portfolio optimization random instance method"""
         import matplotlib.pyplot as plt

--- a/src/openqaoa-core/tests/test_results.py
+++ b/src/openqaoa-core/tests/test_results.py
@@ -2,6 +2,7 @@ import unittest
 import itertools
 import networkx as nw
 import numpy as np
+import matplotlib.pyplot as plt
 
 from openqaoa import QAOA, RQAOA
 from openqaoa.algorithms import QAOAResult, RQAOAResult
@@ -658,7 +659,7 @@ class TestingRQAOAResultOutputs(unittest.TestCase):
         # test the plot_corr_matrix method
         for i in range(results["number_steps"]):
             fig, _ = results.plot_corr_matrix(step=i)
-            fig.close()
+            plt.close(fig)
 
     def test_rqaoa_result_asdict(self):
         """

--- a/src/openqaoa-core/tests/test_results.py
+++ b/src/openqaoa-core/tests/test_results.py
@@ -657,7 +657,8 @@ class TestingRQAOAResultOutputs(unittest.TestCase):
 
         # test the plot_corr_matrix method
         for i in range(results["number_steps"]):
-            results.plot_corr_matrix(step=i)
+            fig, _ = results.plot_corr_matrix(step=i)
+            fig.close()
 
     def test_rqaoa_result_asdict(self):
         """

--- a/src/openqaoa-core/tests/test_sk.py
+++ b/src/openqaoa-core/tests/test_sk.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 import networkx as nx
 import numpy as np
 import matplotlib.pyplot as plt
@@ -100,6 +101,7 @@ class TestSK(unittest.TestCase):
                 "Input problem graph must be a networkx Graph.", str(e.exception)
             )
 
+    @pytest.mark.cplex
     def test_sk_classical_sol(self):
         """Test the SK random instance method classical solution"""
 

--- a/src/openqaoa-core/tests/test_tsp.py
+++ b/src/openqaoa-core/tests/test_tsp.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 import networkx as nx
 import numpy as np
 import matplotlib.pyplot as plt
@@ -265,6 +266,7 @@ class TestTSP_LP(unittest.TestCase):
         self.assertEqual(expected_weights, tsp_qubo.weights)
         self.assertEqual(expected_constant, tsp_qubo.constant)
 
+    @pytest.mark.cplex
     def test_tsp_lp_length(self):
         """Testing TSP LP problem creation"""
         cities = 3
@@ -273,6 +275,7 @@ class TestTSP_LP(unittest.TestCase):
         distance_expected = 2.4792766646401967
         self.assertEqual(distance_expected, tsp.get_distance(solution))
 
+    @pytest.mark.cplex
     def test_tsp_lp_plot(self):
         """Testing TSP LP problem creation"""
 

--- a/src/openqaoa-core/tests/test_vrp.py
+++ b/src/openqaoa-core/tests/test_vrp.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 import networkx as nx
 import numpy as np
 import matplotlib.pyplot as plt
@@ -212,6 +213,7 @@ class TestVRP(unittest.TestCase):
         self.assertTrue(vrp_prob_random.terms[0] == [0, 1])
         self.assertTrue(vrp_prob_random.terms[-1] == [27])
 
+    @pytest.mark.cplex
     def test_vrp_plot(self):
         """
         Testing the random_instance method of the VRP problem class using the
@@ -238,6 +240,7 @@ class TestVRP(unittest.TestCase):
         self.assertEqual(type(ax_vrp_str), plt.Axes)
         plt.close(fig_vrp_str)
 
+    @pytest.mark.cplex
     def test_vrp_type_checking(self):
         """
         Checks if the type-checking returns the right error.

--- a/src/openqaoa-pyquil/openqaoa_pyquil/backends/qaoa_pyquil_qpu.py
+++ b/src/openqaoa-pyquil/openqaoa_pyquil/backends/qaoa_pyquil_qpu.py
@@ -300,9 +300,9 @@ class QAOAPyQuilQPUBackend(
             if each_gate.gate_label.type.value in ["MIXER", "COST"]:
                 gatelabel_pyquil = each_gate.gate_label.__repr__()
                 gatelabel_pyquil = (
-                    "one" + gatelabel_pyquil[1:]
+                    "one" + gatelabel_pyquil[3:]
                     if each_gate.gate_label.n_qubits == 1
-                    else "two" + gatelabel_pyquil[1:]
+                    else "two" + gatelabel_pyquil[3:]
                 )
                 angle_param = parametric_circuit.declare(gatelabel_pyquil.lower(), "REAL", 1)
                 each_gate.angle_value = angle_param

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -112,5 +112,6 @@ def test_portfolio_optimization():
 
 
 # @pytest.mark.notebook
+@pytest.mark.cplex
 def test_binpacking():
     notebook_test_function("./examples/community_tutorials/04_binpacking.ipynb")

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -100,11 +100,13 @@ def test_tutorial_quantum_approximate_optimization_algorithm():
 
 
 # @pytest.mark.notebook
+@pytest.mark.cplex
 def test_docplex_example():
     notebook_test_function("./examples/community_tutorials/02_docplex_example.ipynb")
 
 
 # @pytest.mark.notebook
+@pytest.mark.cplex
 def test_portfolio_optimization():
     notebook_test_function(
         "./examples/community_tutorials/03_portfolio_optimization.ipynb"


### PR DESCRIPTION
## Description

- Limits the `numpy` version to `1.x`
- Fixes the failing workflow tests for CPLEX
  - Classical solutions computed using IBM ILOG CPLEX Optimization Studio are not tested on MacOS and Windows because they need a license.
  - The are still tested on a Linux environment
- Added better handling of figures in general
- Fixed angles naming convention to fit AWS braket changes + fixed pyquil compatibility
- Fixed a failing test in `openqaoa/src/openqaoa-core/tests/test_workflows.py` due to conversion errors
  - Changed `assert` into `assertAlmostEqual`.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code and used numpy-style docstrings
- [x] I have made corresponding updates to the documentation.
- [x] My changes generate no new warnings
- [x] I have added/updated tests to make sure bugfix/feature works.
- [x] New and existing unit tests pass locally with my changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
