### PR TITLE
Fix RYYGate decomposition bug

### DIFF
--- a/src/openqaoa-core/openqaoa/qaoa_components/ansatz_constructor/gatemap.py
+++ b/src/openqaoa-core/openqaoa/qaoa_components/ansatz_constructor/gatemap.py
@@ -246,8 +246,8 @@ class RYYGateMap(TwoQubitRotationGateMap):
             ),
             (CX, [self.qubit_1, self.qubit_2]),
             (
-                RY,
-                [self.qubit_2, RotationAngle(lambda x: x, self.gate_label, -np.pi / 2)],
+                RX,
+                [self.qubit_1, RotationAngle(lambda x: x, self.gate_label, -np.pi / 2)],
             ),
             (
                 RX,


### PR DESCRIPTION
## Description

This pull request addresses a bug in the implementation of the RYY gate within the `RYYGateMap` class, located in `src/openqaoa-core/openqaoa/qaoa_components/ansatz_constructor/gatemap.py`. The issue was causing incorrect gate behavior, affecting the accuracy of quantum circuit simulations running in the cloud environment.

## Changes:
Corrected the mathematical decomposition of the RYY gate.

## Bug Description:
The previous implementation of the RYY gate decomposition had an error in the rotation parameters, which led to unexpected results in our quantum algorithms. This fix corrects the parameters to align with the standard definition of the RYY gate.

## Impact:
This fix is critical for any application relying on the accurate implementation of the RYY gate. It ensures that our quantum algorithms perform as expected and that the results are reliable.

Please review the changes and let me know if there are any questions or further modifications needed.

## Checklist

[//]: <> (- [ ] My code follows the style guidelines of this project)

- [x] I have performed a self-review of my code.
- [ ] I have commented my code and used numpy-style docstrings
- [ ] I have made corresponding updates to the documentation.
- [x] My changes generate no new warnings
- [ ] I have added/updated tests to make sure bugfix/feature works.
- [ ] New and existing unit tests pass locally with my changes.

[//]: <> (- [ ] Any dependent changes have been merged and published in downstream modules)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
